### PR TITLE
Fix LD_LIBRARY_PATH export in BUILD_NOTES_tch.txt

### DIFF
--- a/BUILD_NOTES_tch.txt
+++ b/BUILD_NOTES_tch.txt
@@ -9,7 +9,7 @@ Then set the following environment variables:
 
 export LIBTORCH={path/to/}libtorch
 export DYLD_LIBRARY_PATH=${LIBTORCH}/lib
-export LD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${DYLD_LIBRARY_PATH}
 
 You can check that everything is working by running `modkit open-chromatin predict <args> --dryrun`.
 


### PR DESCRIPTION
Updated LD_LIBRARY_PATH export to append DYLD_LIBRARY_PATH.

As discussed in https://github.com/nanoporetech/modkit/issues/491 