### PR TITLE
Feat/support reference group for modkit dmr multi

### DIFF
--- a/book/src/intro_dmr.md
+++ b/book/src/intro_dmr.md
@@ -113,6 +113,23 @@ For example the samples could be haplotype-partitioned bedMethyl tables or biolo
 Unlike for `modkit dmr pair` a sample name (e.g. `norm1` and `tumor1` above) must be provided for each input
 sample.
 
+If you have many samples but a single reference sample you can use the `--ref-sample` option to specify the reference sample to be used for all comparisons. This is useful for large datasets with many samples where you are not interested in all pairwise comparisons to reduce computation.
+
+```bash
+modkit dmr multi \
+  -s ${norm_pileup_1}.gz norm1 \
+  -s ${tumor_pileup_1}.gz tumor1 \
+  -s ${tumor_pileup_2}.gz tumor2 \
+  -o ${dmr_dir} \ # required for multi
+  -r ${cpg_islands} \ # skip this option to perform base-level DMR
+  --ref ${ref} \
+  --ref-sample norm1 \ # use norm1 as the reference for all comparisons
+  --base C \
+  -t 10 \
+  -f \
+  --log-filepath dmr_multi.log
+```
+
 ## 3. Detecting differential modification at single base positions
 The `modkit dmr pair` command has the ability to score individual bases (e.g. differentially methylated CpGs).
 To run single-base analysis on one or more paired samples, simply omit the `--regions` (`-r`) option when running `modkit dmr pair`.
@@ -314,4 +331,3 @@ The output schema for the segments is:
 | 14     | cohen_h                              | Cohen's h [statistic](https://en.wikipedia.org/wiki/Cohen%27s_h) (useful with regions and high-depth runs) | float |
 | 15     | cohen_h_low                          | 95% confidence interval lower bound                                                                   | float |
 | 16     | cohen_h_high                         | 95% confidence interval upper bound                                                                   | float |
-

--- a/modkit-core/src/dmr/subcommands.rs
+++ b/modkit-core/src/dmr/subcommands.rs
@@ -853,7 +853,9 @@ impl MultiSampleDmr {
         }
 
         // Generate sample pairs based on whether a reference sample is specified
-        let sample_pairs: Vec<(&String, &String)> = if let Some(ref_name) = &self.ref_sample {
+        let sample_pairs: Vec<(&String, &String)> = if let Some(ref_name) =
+            &self.ref_sample
+        {
             // Validate that the reference sample exists
             if !names.contains_key(ref_name) {
                 return Err(anyhow::anyhow!(
@@ -865,22 +867,27 @@ impl MultiSampleDmr {
             info!("using reference sample: {}", ref_name);
 
             // Compare all samples against the reference
-            names.keys()
+            names
+                .keys()
                 .filter(|name| *name != ref_name)
                 .map(|name| (ref_name, name))
                 .collect()
         } else {
             // All pairwise comparisons
             let samples = names.keys().sorted().collect::<Vec<&String>>();
-            samples.into_iter()
+            samples
+                .into_iter()
                 .combinations(2)
                 .map(|pair| (pair[0], pair[1]))
                 .collect()
         };
 
-        let sample_pb = mpb.add(get_master_progress_bar(sample_pairs.len() as u64));
+        let sample_pb =
+            mpb.add(get_master_progress_bar(sample_pairs.len() as u64));
 
-        for (a_name, b_name) in sample_pairs.into_iter().progress_with(sample_pb.clone()) {
+        for (a_name, b_name) in
+            sample_pairs.into_iter().progress_with(sample_pb.clone())
+        {
             let a_idxs = names.get(a_name).unwrap();
             let b_idxs = names.get(b_name).unwrap();
 

--- a/modkit-core/src/dmr/subcommands.rs
+++ b/modkit-core/src/dmr/subcommands.rs
@@ -855,11 +855,11 @@ impl MultiSampleDmr {
         {
             // Validate that the reference sample exists
             if !names.contains_key(ref_name) {
-                return Err(anyhow::anyhow!(
+                bail!(
                     "reference sample '{}' not found in provided samples. Available samples: {}",
                     ref_name,
                     names.keys().sorted().map(|s| s.as_str()).collect::<Vec<_>>().join(", ")
-                ));
+                );
             }
             info!("using reference sample: {}", ref_name);
 

--- a/modkit-core/src/dmr/subcommands.rs
+++ b/modkit-core/src/dmr/subcommands.rs
@@ -717,10 +717,7 @@ pub struct MultiSampleDmr {
     #[clap(help_heading = "Sample Options")]
     #[arg(long, alias = "min-coverage", default_value_t = 0)]
     min_valid_coverage: u64,
-    /// Reference sample name to compare all other samples against. When
-    /// provided, only performs comparisons between this reference and all
-    /// other samples, instead of all pairwise comparisons. The reference
-    /// sample must match one of the sample names provided via --sample.
+    /// Only performs comparisons between this sample and all other samples.
     #[clap(help_heading = "Sample Options")]
     #[arg(long)]
     ref_sample: Option<String>,

--- a/modkit-core/src/dmr/subcommands.rs
+++ b/modkit-core/src/dmr/subcommands.rs
@@ -717,6 +717,13 @@ pub struct MultiSampleDmr {
     #[clap(help_heading = "Sample Options")]
     #[arg(long, alias = "min-coverage", default_value_t = 0)]
     min_valid_coverage: u64,
+    /// Reference sample name to compare all other samples against. When
+    /// provided, only performs comparisons between this reference and all
+    /// other samples, instead of all pairwise comparisons. The reference
+    /// sample must match one of the sample names provided via --sample.
+    #[clap(help_heading = "Sample Options")]
+    #[arg(long)]
+    ref_sample: Option<String>,
 }
 
 impl MultiSampleDmr {
@@ -845,15 +852,35 @@ impl MultiSampleDmr {
             info!("calculating differntial methylation for {code} in isolation")
         }
 
-        let sample_pb =
-            mpb.add(get_master_progress_bar(sample_index.num_combinations()?));
+        // Generate sample pairs based on whether a reference sample is specified
+        let sample_pairs: Vec<(&String, &String)> = if let Some(ref_name) = &self.ref_sample {
+            // Validate that the reference sample exists
+            if !names.contains_key(ref_name) {
+                return Err(anyhow::anyhow!(
+                    "reference sample '{}' not found in provided samples. Available samples: {}",
+                    ref_name,
+                    names.keys().sorted().map(|s| s.as_str()).collect::<Vec<_>>().join(", ")
+                ));
+            }
+            info!("using reference sample: {}", ref_name);
 
-        let samples = names.keys().sorted().collect::<Vec<&String>>();
-        for pair in
-            samples.into_iter().combinations(2).progress_with(sample_pb.clone())
-        {
-            let a_name = pair[0];
-            let b_name = pair[1];
+            // Compare all samples against the reference
+            names.keys()
+                .filter(|name| *name != ref_name)
+                .map(|name| (ref_name, name))
+                .collect()
+        } else {
+            // All pairwise comparisons
+            let samples = names.keys().sorted().collect::<Vec<&String>>();
+            samples.into_iter()
+                .combinations(2)
+                .map(|pair| (pair[0], pair[1]))
+                .collect()
+        };
+
+        let sample_pb = mpb.add(get_master_progress_bar(sample_pairs.len() as u64));
+
+        for (a_name, b_name) in sample_pairs.into_iter().progress_with(sample_pb.clone()) {
             let a_idxs = names.get(a_name).unwrap();
             let b_idxs = names.get(b_name).unwrap();
 

--- a/modkit-core/src/dmr/tabix.rs
+++ b/modkit-core/src/dmr/tabix.rs
@@ -140,6 +140,7 @@ impl MultiSampleIndex {
         Ok((a, b))
     }
 
+    #[allow(unused)]
     pub(super) fn num_combinations(&self) -> anyhow::Result<usize> {
         n_choose_2(self.index_handlers.len())
     }


### PR DESCRIPTION
This is a small PR that reduces the number of pairwise combinations for `modkit dmr multi` when there is a single reference sample. This can heavily reduce computation when only only a comparison to a single reference is necessary. 