### PR TITLE
Fixes for documentation issues noted for `dmr compare-tx-sites`

### DIFF
--- a/book/src/intro_compare_tx_sites.md
+++ b/book/src/intro_compare_tx_sites.md
@@ -26,7 +26,7 @@ modkit dmr compare-tx-sites \
   -a ${bedmethyl_a} \
   -b ${bedmethyl_b} \
   --out ${output.bed} \
-  --single-mod-code a \
+  --single-code a \
   --plot volcano.svg \
   --gtf ${gtf} \
   --log debug.log
@@ -53,12 +53,13 @@ These data were downloaded from the reference [You et al., Benchmarking long-rea
 | 8      | gene_id | gene-id from the GTF                                                  | str |
 | 9      | gene_name | gene-name from the GTF or '-' if not found                                                  | str |
 | 10      | log2_fold_change | log base 2 fold change                                                  | float |
-| 11      | cond_a_proportions | JSON formatted string of condition 'A' per-modification proprotions                                                  | str |
-| 12      | cond_b_proportions | JSON formatted string of condition 'B' per-modification proprotions                                                  | str |
-| 13      | cond_a_counts | JSON formatted string of condition 'A' per-modification counts                                                  | str |
-| 14      | cond_b_counts | JSON formatted string of condition 'B' per-modification counts                                                  | str |
+| 11      | effect_size | difference in modification proportions between conditions | float |
+| 12      | cond_a_proportions | JSON formatted string of condition 'A' per-modification proprotions                                                  | str |
+| 13      | cond_b_proportions | JSON formatted string of condition 'B' per-modification proprotions                                                  | str |
+| 14      | cond_a_counts | JSON formatted string of condition 'A' per-modification counts                                                  | str |
+| 15      | cond_b_counts | JSON formatted string of condition 'B' per-modification counts                                                  | str |
 
-Columns 11 through 14 are only present when the `--full` flag is passed.
+Columns 11 through 15 are only present when the `--full` flag is passed.
 
 
 


### PR DESCRIPTION
This fixes the two documentation issues noted in #622 
Updated the command option from '--single-mod-code' to '--single-code' and added a new column for 'effect_size' in the documentation.