### PR TITLE
Add `--min-samples` and `--min-sample-coverage` to `bedmethyl merge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Adds
-  - [bedmethyl] Adds `--min-samples` and `--min-sample-coverage` to `bedmethyl merge` to require a position to be present in (and optionally covered to a minimum valid depth in) multiple inputs, enabling an inner join across replicates. The defaults preserve the original outer-join behaviour.
+  - [bedmethyl] Adds `--min-samples` (an integer or `all`) and `--min-sample-coverage` to `bedmethyl merge` to require a position to be present in (and optionally covered to a minimum valid depth in) multiple inputs, enabling an inner join across replicates. Omitting them preserves the original outer-join behaviour.
 
 ## [v0.6.3]
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Adds
+  - [bedmethyl] Adds `--min-samples` and `--min-sample-coverage` to `bedmethyl merge` to require a position to be present in (and optionally covered to a minimum valid depth in) multiple inputs, enabling an inner join across replicates. The defaults preserve the original outer-join behaviour.
+
 ## [v0.6.3]
 ### Adds
   - [dmr] Adds `dmr isoform` for comparing methylation across isoforms of genes

--- a/book/src/advanced_usage.md
+++ b/book/src/advanced_usage.md
@@ -2970,8 +2970,7 @@ Options:
 ## bedmethyl merge
 ```text
 Perform an outer join on two or more bedMethyl files, summing their counts for
-records that overlap. Use --min-samples to instead require a position to be
-present in multiple inputs (e.g. an inner join across replicates)
+records that overlap
 
 Usage: modkit bedmethyl merge [OPTIONS] --out-bed <OUT_BED> --genome-sizes <GENOME_SIZES> [IN_BEDMETHYL] [IN_BEDMETHYL]...
 
@@ -3039,22 +3038,13 @@ Logging Options:
 
 Filtering Options:
       --min-samples <MIN_SAMPLES>
-          Only output a position if it is present in at least this many input
-          bedMethyl files. The default of 1 performs an outer join (a position
-          is kept if any input has it). Set this to the number of inputs to
-          perform an inner join (a position is kept only if every input has it),
-          which is useful for retaining reproducible positions across replicates
-          
-          [default: 1]
+          Only output a position present in at least this many input bedMethyl
+          files. Accepts an integer greater than 1, or "all" to require the
+          position in every input (an inner join across replicates)
 
       --min-sample-coverage <MIN_SAMPLE_COVERAGE>
           Minimum valid coverage for an input's record to count towards a
-          position. An input only contributes to a position (both for the
-          --min-samples tally and for the summed counts) when that input's
-          record has at least this valid coverage. The default of 0 counts any
-          record that is present
-          
-          [default: 0]
+          position, for both the --min-samples tally and the summed counts
 ```
 
 ## bedmethyl tobigwig

--- a/book/src/advanced_usage.md
+++ b/book/src/advanced_usage.md
@@ -2970,7 +2970,8 @@ Options:
 ## bedmethyl merge
 ```text
 Perform an outer join on two or more bedMethyl files, summing their counts for
-records that overlap
+records that overlap. Use --min-samples to instead require a position to be
+present in multiple inputs (e.g. an inner join across replicates)
 
 Usage: modkit bedmethyl merge [OPTIONS] --out-bed <OUT_BED> --genome-sizes <GENOME_SIZES> [IN_BEDMETHYL] [IN_BEDMETHYL]...
 
@@ -3035,6 +3036,25 @@ Compute Options:
 Logging Options:
       --log-filepath <LOG_FILEPATH>
           Specify a file to write debug logs to
+
+Filtering Options:
+      --min-samples <MIN_SAMPLES>
+          Only output a position if it is present in at least this many input
+          bedMethyl files. The default of 1 performs an outer join (a position
+          is kept if any input has it). Set this to the number of inputs to
+          perform an inner join (a position is kept only if every input has it),
+          which is useful for retaining reproducible positions across replicates
+          
+          [default: 1]
+
+      --min-sample-coverage <MIN_SAMPLE_COVERAGE>
+          Minimum valid coverage for an input's record to count towards a
+          position. An input only contributes to a position (both for the
+          --min-samples tally and for the summed counts) when that input's
+          record has at least this valid coverage. The default of 0 counts any
+          record that is present
+          
+          [default: 0]
 ```
 
 ## bedmethyl tobigwig

--- a/book/src/intro_bedmethyl_merge.md
+++ b/book/src/intro_bedmethyl_merge.md
@@ -32,6 +32,39 @@ chr1    249250621
 chr2    243199373
 ```
 
+## Requiring positions in multiple samples (inner join)
+
+By default `merge` performs an outer join: a position is kept if it appears in
+any input. To instead keep only positions shared across inputs, use
+`--min-samples`. A position is output only when it appears in at least that many
+input files. Setting `--min-samples` to the number of inputs performs an inner
+join, which is useful for retaining positions that reproduce across replicates.
+
+```bash
+# keep only positions present in all three replicates (inner join)
+modkit bedmethyl merge rep1.bed.gz rep2.bed.gz rep3.bed.gz \
+  -o replicates_inner.bed \
+  -g genome_sizes.tsv \
+  --min-samples 3
+```
+
+`--min-sample-coverage` adds a per-input confidence floor: an input only counts
+towards a position (both for the `--min-samples` tally and for the summed counts)
+when that input's record has at least the given valid coverage. For example, to
+require a position to be covered by at least 5 valid reads in all three
+replicates:
+
+```bash
+modkit bedmethyl merge rep1.bed.gz rep2.bed.gz rep3.bed.gz \
+  -o replicates_inner_cov5.bed \
+  -g genome_sizes.tsv \
+  --min-samples 3 \
+  --min-sample-coverage 5
+```
+
+The defaults (`--min-samples 1`, `--min-sample-coverage 0`) reproduce the
+original outer-join behaviour.
+
 # Convert bedMethyl to bigWig
 
 You may want to convert a bedMethyl to bigWig for easier visualization on a genome browser. 

--- a/book/src/intro_bedmethyl_merge.md
+++ b/book/src/intro_bedmethyl_merge.md
@@ -36,16 +36,17 @@ chr2    243199373
 
 By default `merge` performs an outer join: a position is kept if it appears in
 any input. To instead keep only positions shared across inputs, use
-`--min-samples`. A position is output only when it appears in at least that many
-input files. Setting `--min-samples` to the number of inputs performs an inner
-join, which is useful for retaining positions that reproduce across replicates.
+`--min-samples`, which outputs a position only when it appears in at least that
+many input files. Pass `--min-samples all` to require the position in every
+input (an inner join), which is useful for retaining positions that reproduce
+across replicates; `all` avoids hard-coding the input count in scripts.
 
 ```bash
 # keep only positions present in all three replicates (inner join)
 modkit bedmethyl merge rep1.bed.gz rep2.bed.gz rep3.bed.gz \
   -o replicates_inner.bed \
   -g genome_sizes.tsv \
-  --min-samples 3
+  --min-samples all
 ```
 
 `--min-sample-coverage` adds a per-input confidence floor: an input only counts
@@ -58,12 +59,11 @@ replicates:
 modkit bedmethyl merge rep1.bed.gz rep2.bed.gz rep3.bed.gz \
   -o replicates_inner_cov5.bed \
   -g genome_sizes.tsv \
-  --min-samples 3 \
+  --min-samples all \
   --min-sample-coverage 5
 ```
 
-The defaults (`--min-samples 1`, `--min-sample-coverage 0`) reproduce the
-original outer-join behaviour.
+Omitting both options reproduces the original outer-join behaviour.
 
 # Convert bedMethyl to bigWig
 

--- a/book/src/intro_bedmethyl_merge.md
+++ b/book/src/intro_bedmethyl_merge.md
@@ -63,7 +63,7 @@ modkit bedmethyl merge rep1.bed.gz rep2.bed.gz rep3.bed.gz \
   --min-sample-coverage 5
 ```
 
-Omitting both options reproduces the original outer-join behaviour.
+Omitting both options performs an outer-join.
 
 # Convert bedMethyl to bigWig
 

--- a/modkit-core/src/bedmethyl_util/subcommands.rs
+++ b/modkit-core/src/bedmethyl_util/subcommands.rs
@@ -75,11 +75,13 @@ fn parse_min_samples(s: &str) -> Result<MinSamples, String> {
     if s.eq_ignore_ascii_case("all") {
         return Ok(MinSamples::All);
     }
+    // A value of 1 is rejected: it would keep every position (an outer join),
+    // which is the behaviour when the option is omitted, so it does nothing.
     match s.parse::<usize>() {
-        Ok(n) if n >= 1 => Ok(MinSamples::AtLeast(n)),
-        Ok(_) => Err("must be a positive integer or \"all\"".to_string()),
+        Ok(n) if n > 1 => Ok(MinSamples::AtLeast(n)),
+        Ok(_) => Err("must be an integer greater than 1, or \"all\"".to_string()),
         Err(_) => Err(format!(
-            "invalid value '{s}': expected a positive integer or \"all\""
+            "invalid value '{s}': expected an integer greater than 1 or \"all\""
         )),
     }
 }
@@ -165,8 +167,8 @@ pub struct EntryMergeBedMethyl {
     io_threads: usize,
 
     /// Only output a position present in at least this many input bedMethyl
-    /// files. Accepts an integer, or "all" to require the position in every
-    /// input (an inner join across replicates).
+    /// files. Accepts an integer greater than 1, or "all" to require the
+    /// position in every input (an inner join across replicates).
     #[clap(help_heading = "Filtering Options")]
     #[arg(long, value_parser = parse_min_samples)]
     min_samples: Option<MinSamples>,

--- a/modkit-core/src/bedmethyl_util/subcommands.rs
+++ b/modkit-core/src/bedmethyl_util/subcommands.rs
@@ -41,7 +41,9 @@ use crate::writers::bedmethyl_header;
 #[derive(Subcommand)]
 pub enum EntryBedMethyl {
     /// Perform an outer join on two or more bedMethyl files, summing their
-    /// counts for records that overlap
+    /// counts for records that overlap. Use --min-samples to instead require a
+    /// position to be present in multiple inputs (e.g. an inner join across
+    /// replicates).
     #[command(name = "merge")]
     MergeBedMethyl(EntryMergeBedMethyl),
     /// Make a BigWig track from a bedMethyl file or stream.
@@ -143,6 +145,22 @@ pub struct EntryMergeBedMethyl {
     #[clap(help_heading = "Compute Options")]
     #[arg(long, default_value_t = 2)]
     io_threads: usize,
+
+    /// Only output a position if it is present in at least this many input
+    /// bedMethyl files. The default of 1 performs an outer join (a position is
+    /// kept if any input has it). Set this to the number of inputs to perform an
+    /// inner join (a position is kept only if every input has it), which is
+    /// useful for retaining reproducible positions across replicates.
+    #[clap(help_heading = "Filtering Options")]
+    #[arg(long, default_value_t = 1)]
+    min_samples: usize,
+    /// Minimum valid coverage for an input's record to count towards a position.
+    /// An input only contributes to a position (both for the --min-samples tally
+    /// and for the summed counts) when that input's record has at least this
+    /// valid coverage. The default of 0 counts any record that is present.
+    #[clap(help_heading = "Filtering Options")]
+    #[arg(long, default_value_t = 0)]
+    min_sample_coverage: u64,
 }
 
 type BedMethylChunk = Vec<BedMethylLine>;
@@ -152,13 +170,18 @@ fn merge_data(
     chrom_coordinates: ChromCoordinates,
     tid_to_name: &FxHashMap<u32, String>,
     io_threads: usize,
+    min_samples: usize,
+    min_sample_coverage: u64,
 ) -> anyhow::Result<BedMethylChunk> {
     type Key = (u64, ModCodeRepr, StrandRule);
     // this is safe because of how we constructed this
     let contig = tid_to_name.get(&chrom_coordinates.chrom_tid).unwrap();
     let range = (chrom_coordinates.start_pos as u64)
         ..(chrom_coordinates.end_pos as u64);
-    let mut merged_data = FxHashMap::<Key, BedMethylLine>::default();
+    // value is the merged record plus a tally of how many inputs contributed to
+    // it (each input has at most one record per key), used for the --min-samples
+    // (inner-join) filter below.
+    let mut merged_data = FxHashMap::<Key, (BedMethylLine, usize)>::default();
 
     // rationale:
     // iterate over every possible contig
@@ -173,10 +196,16 @@ fn merge_data(
         for line in lines {
             let line = line?;
 
+            // an input only contributes to a position when its record has at
+            // least the requested valid coverage
+            if line.valid_coverage < min_sample_coverage {
+                continue;
+            }
+
             merged_data
                 .entry((line.start(), line.raw_mod_code, line.strand))
                 // modify the methyl data if an entry is found
-                .and_modify(|methyl| {
+                .and_modify(|(methyl, n_samples)| {
                     methyl.count_methylated += line.count_methylated;
                     methyl.valid_coverage += line.valid_coverage;
                     methyl.count_canonical += line.count_canonical;
@@ -185,14 +214,18 @@ fn merge_data(
                     methyl.count_fail += line.count_fail;
                     methyl.count_diff += line.count_diff;
                     methyl.count_nocall += line.count_nocall;
+                    *n_samples += 1;
                 })
-                .or_insert(line);
+                .or_insert((line, 1));
         }
     }
 
-    // get just the bedmethyllines for writing
+    // get just the bedmethyllines for writing, keeping only positions present in
+    // at least --min-samples inputs (default 1 == outer join, unchanged)
     let merged_data = merged_data
         .into_values()
+        .filter(|(_, n_samples)| *n_samples >= min_samples)
+        .map(|(methyl, _)| methyl)
         .sorted_by(|a, b| {
             debug_assert_eq!(a.chrom, b.chrom);
             match a.start().cmp(&b.start()) {
@@ -211,6 +244,18 @@ fn merge_data(
 impl EntryMergeBedMethyl {
     pub fn run(&self) -> anyhow::Result<()> {
         let _handle = init_logging(self.log_filepath.as_ref());
+
+        if self.min_samples < 1 {
+            bail!("--min-samples must be at least 1");
+        }
+        if self.min_samples > self.in_bedmethyl.len() {
+            warn!(
+                "--min-samples ({}) is greater than the number of input \
+                 bedMethyl files ({}); no positions will be output",
+                self.min_samples,
+                self.in_bedmethyl.len()
+            );
+        }
 
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(self.threads)
@@ -322,6 +367,8 @@ impl EntryMergeBedMethyl {
         gauge.set_position(snd.len() as u64);
 
         let io_threads = self.io_threads;
+        let min_samples = self.min_samples;
+        let min_sample_coverage = self.min_sample_coverage;
         pool.spawn(move || {
             feeder
                 .into_iter()
@@ -343,6 +390,8 @@ impl EntryMergeBedMethyl {
                                     chrom_coordinates,
                                     &tid_to_name,
                                     io_threads,
+                                    min_samples,
+                                    min_sample_coverage,
                                 )
                             })
                         })

--- a/modkit-core/src/bedmethyl_util/subcommands.rs
+++ b/modkit-core/src/bedmethyl_util/subcommands.rs
@@ -41,9 +41,7 @@ use crate::writers::bedmethyl_header;
 #[derive(Subcommand)]
 pub enum EntryBedMethyl {
     /// Perform an outer join on two or more bedMethyl files, summing their
-    /// counts for records that overlap. Use --min-samples to instead require a
-    /// position to be present in multiple inputs (e.g. an inner join across
-    /// replicates).
+    /// counts for records that overlap
     #[command(name = "merge")]
     MergeBedMethyl(EntryMergeBedMethyl),
     /// Make a BigWig track from a bedMethyl file or stream.
@@ -63,6 +61,26 @@ impl EntryBedMethyl {
             EntryBedMethyl::ToBigWig(x) => x.run(),
             EntryBedMethyl::MapToGenome(x) => x.run(),
         }
+    }
+}
+
+/// Value of `--min-samples`: either an explicit count or every input ("all").
+#[derive(Clone, Debug)]
+enum MinSamples {
+    All,
+    AtLeast(usize),
+}
+
+fn parse_min_samples(s: &str) -> Result<MinSamples, String> {
+    if s.eq_ignore_ascii_case("all") {
+        return Ok(MinSamples::All);
+    }
+    match s.parse::<usize>() {
+        Ok(n) if n >= 1 => Ok(MinSamples::AtLeast(n)),
+        Ok(_) => Err("must be a positive integer or \"all\"".to_string()),
+        Err(_) => Err(format!(
+            "invalid value '{s}': expected a positive integer or \"all\""
+        )),
     }
 }
 
@@ -146,21 +164,17 @@ pub struct EntryMergeBedMethyl {
     #[arg(long, default_value_t = 2)]
     io_threads: usize,
 
-    /// Only output a position if it is present in at least this many input
-    /// bedMethyl files. The default of 1 performs an outer join (a position is
-    /// kept if any input has it). Set this to the number of inputs to perform an
-    /// inner join (a position is kept only if every input has it), which is
-    /// useful for retaining reproducible positions across replicates.
+    /// Only output a position present in at least this many input bedMethyl
+    /// files. Accepts an integer, or "all" to require the position in every
+    /// input (an inner join across replicates).
     #[clap(help_heading = "Filtering Options")]
-    #[arg(long, default_value_t = 1)]
-    min_samples: usize,
-    /// Minimum valid coverage for an input's record to count towards a position.
-    /// An input only contributes to a position (both for the --min-samples tally
-    /// and for the summed counts) when that input's record has at least this
-    /// valid coverage. The default of 0 counts any record that is present.
+    #[arg(long, value_parser = parse_min_samples)]
+    min_samples: Option<MinSamples>,
+    /// Minimum valid coverage for an input's record to count towards a position,
+    /// for both the --min-samples tally and the summed counts.
     #[clap(help_heading = "Filtering Options")]
-    #[arg(long, default_value_t = 0)]
-    min_sample_coverage: u64,
+    #[arg(long)]
+    min_sample_coverage: Option<u64>,
 }
 
 type BedMethylChunk = Vec<BedMethylLine>;
@@ -245,17 +259,22 @@ impl EntryMergeBedMethyl {
     pub fn run(&self) -> anyhow::Result<()> {
         let _handle = init_logging(self.log_filepath.as_ref());
 
-        if self.min_samples < 1 {
-            bail!("--min-samples must be at least 1");
-        }
-        if self.min_samples > self.in_bedmethyl.len() {
-            warn!(
+        // Resolve --min-samples ("all" -> number of inputs; omitted -> 1 = outer join).
+        let n_inputs = self.in_bedmethyl.len();
+        let min_samples: usize = match &self.min_samples {
+            None => 1,
+            Some(MinSamples::All) => n_inputs,
+            Some(MinSamples::AtLeast(n)) => *n,
+        };
+        if min_samples > n_inputs {
+            bail!(
                 "--min-samples ({}) is greater than the number of input \
-                 bedMethyl files ({}); no positions will be output",
-                self.min_samples,
-                self.in_bedmethyl.len()
+                 bedMethyl files ({})",
+                min_samples,
+                n_inputs
             );
         }
+        let min_sample_coverage: u64 = self.min_sample_coverage.unwrap_or(0);
 
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(self.threads)
@@ -367,8 +386,6 @@ impl EntryMergeBedMethyl {
         gauge.set_position(snd.len() as u64);
 
         let io_threads = self.io_threads;
-        let min_samples = self.min_samples;
-        let min_sample_coverage = self.min_sample_coverage;
         pool.spawn(move || {
             feeder
                 .into_iter()

--- a/modkit/tests/test_bedmethyl_util.rs
+++ b/modkit/tests/test_bedmethyl_util.rs
@@ -106,9 +106,10 @@ fn test_bedmethyl_merge_min_samples() {
 
     // Decode the input once to know how many positions it has.
     let mut buff = vec![];
-    let _ = rust_htslib::bgzf::Reader::from_path(MIN_SAMPLES_BED_FP)
+    rust_htslib::bgzf::Reader::from_path(MIN_SAMPLES_BED_FP)
         .unwrap()
-        .read_to_end(&mut buff);
+        .read_to_end(&mut buff)
+        .expect("failed to read MIN_SAMPLES_BED_FP fixture");
     let n_positions = buff
         .lines()
         .map(|line| BedMethylLine::parse(&line.unwrap()).unwrap())

--- a/modkit/tests/test_bedmethyl_util.rs
+++ b/modkit/tests/test_bedmethyl_util.rs
@@ -75,3 +75,105 @@ fn test_bedmethyl_merge() {
         assert_eq!(x.count_nocall * 2, y.count_nocall);
     }
 }
+
+// Shared setup helpers for the --min-samples / --min-sample-coverage tests.
+// The committed chr20 pileup resource is passed as multiple inputs: passing it
+// N times makes every position present in exactly N inputs, which lets us
+// exercise the inner-join threshold without building new fixtures.
+fn min_samples_test_sizes() -> std::path::PathBuf {
+    let sizes = "chr20\t64444167\n";
+    let sizes_fp =
+        std::env::temp_dir().join("test_merge_min_samples_sizes.tsv");
+    let mut w = BufWriter::new(File::create(&sizes_fp).unwrap());
+    w.write(sizes.as_bytes()).unwrap();
+    drop(w);
+    sizes_fp
+}
+
+const MIN_SAMPLES_BED_FP: &str = "../tests/resources/\
+    lung_00733-m_adjacent-normal_5mc-5hmc_chr20_cpg_pileup.bed.gz";
+
+fn count_bed_records(fp: &std::path::Path) -> usize {
+    BufReader::new(File::open(fp).unwrap())
+        .lines()
+        .map(|line| BedMethylLine::parse(&line.unwrap()).unwrap())
+        .count()
+}
+
+#[test]
+fn test_bedmethyl_merge_min_samples() {
+    let sizes_fp = min_samples_test_sizes();
+
+    // Decode the input once to know how many positions it has.
+    let mut buff = vec![];
+    let _ = rust_htslib::bgzf::Reader::from_path(MIN_SAMPLES_BED_FP)
+        .unwrap()
+        .read_to_end(&mut buff);
+    let n_positions = buff
+        .lines()
+        .map(|line| BedMethylLine::parse(&line.unwrap()).unwrap())
+        .count();
+
+    // --min-samples 2 with the file passed twice: every position is present in
+    // both inputs, so all positions are kept (an inner join that retains all).
+    let out_keep = std::env::temp_dir().join("test_merge_min_samples_keep.bed");
+    run_modkit(&[
+        "bedmethyl",
+        "merge",
+        MIN_SAMPLES_BED_FP,
+        MIN_SAMPLES_BED_FP,
+        "-g",
+        sizes_fp.to_str().unwrap(),
+        "-o",
+        out_keep.to_str().unwrap(),
+        "--force",
+        "--min-samples",
+        "2",
+    ])
+    .unwrap();
+    assert_eq!(count_bed_records(&out_keep), n_positions);
+
+    // --min-samples 3 with the file passed only twice: every position is
+    // present in just 2 inputs (< 3), so nothing is output.
+    let out_drop = std::env::temp_dir().join("test_merge_min_samples_drop.bed");
+    run_modkit(&[
+        "bedmethyl",
+        "merge",
+        MIN_SAMPLES_BED_FP,
+        MIN_SAMPLES_BED_FP,
+        "-g",
+        sizes_fp.to_str().unwrap(),
+        "-o",
+        out_drop.to_str().unwrap(),
+        "--force",
+        "--min-samples",
+        "3",
+    ])
+    .unwrap();
+    assert_eq!(count_bed_records(&out_drop), 0);
+}
+
+#[test]
+fn test_bedmethyl_merge_min_sample_coverage() {
+    let sizes_fp = min_samples_test_sizes();
+
+    // A very high per-sample valid-coverage floor excludes every record, so no
+    // input contributes to any position and the output is empty.
+    let out_bed =
+        std::env::temp_dir().join("test_merge_min_sample_coverage.bed");
+    run_modkit(&[
+        "bedmethyl",
+        "merge",
+        MIN_SAMPLES_BED_FP,
+        MIN_SAMPLES_BED_FP,
+        "-g",
+        sizes_fp.to_str().unwrap(),
+        "-o",
+        out_bed.to_str().unwrap(),
+        "--force",
+        "--min-sample-coverage",
+        "1000000000",
+    ])
+    .unwrap();
+    assert_eq!(count_bed_records(&out_bed), 0);
+}

--- a/modkit/tests/test_bedmethyl_util.rs
+++ b/modkit/tests/test_bedmethyl_util.rs
@@ -134,9 +134,9 @@ fn test_bedmethyl_merge_min_samples() {
     .unwrap();
     assert_eq!(count_bed_records(&out_keep), n_positions);
 
-    // --min-samples 3 with the file passed only twice: every position is
-    // present in just 2 inputs (< 3), so nothing is output.
-    let out_drop = std::env::temp_dir().join("test_merge_min_samples_drop.bed");
+    // --min-samples all resolves to the number of inputs (2 here), so it is
+    // equivalent to --min-samples 2 and keeps every shared position.
+    let out_all = std::env::temp_dir().join("test_merge_min_samples_all.bed");
     run_modkit(&[
         "bedmethyl",
         "merge",
@@ -145,13 +145,30 @@ fn test_bedmethyl_merge_min_samples() {
         "-g",
         sizes_fp.to_str().unwrap(),
         "-o",
-        out_drop.to_str().unwrap(),
+        out_all.to_str().unwrap(),
+        "--force",
+        "--min-samples",
+        "all",
+    ])
+    .unwrap();
+    assert_eq!(count_bed_records(&out_all), n_positions);
+
+    // --min-samples greater than the number of inputs is an error.
+    let out_err = std::env::temp_dir().join("test_merge_min_samples_err.bed");
+    assert!(run_modkit(&[
+        "bedmethyl",
+        "merge",
+        MIN_SAMPLES_BED_FP,
+        MIN_SAMPLES_BED_FP,
+        "-g",
+        sizes_fp.to_str().unwrap(),
+        "-o",
+        out_err.to_str().unwrap(),
         "--force",
         "--min-samples",
         "3",
     ])
-    .unwrap();
-    assert_eq!(count_bed_records(&out_drop), 0);
+    .is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Adds two optional, backward-compatible flags to `modkit bedmethyl merge` so it can keep only positions that are reproducible across inputs (an inner join), instead of always performing an outer join.

Documented in Feature Request #625 

- `--min-samples <N>` (default `1`): output a position only if it is present in at least `N` input files. `1` reproduces the current outer join; setting `N` = number of inputs performs an inner join.
- `--min-sample-coverage <C>` (default `0`): an input only contributes to a position (both for the `--min-samples` tally and for the summed counts) when that input's record has at least `C` valid coverage.

Defaults (`--min-samples 1`, `--min-sample-coverage 0`) reproduce the existing behaviour exactly.

## Motivation

When merging replicates, the outer join keeps single-replicate (non-reproducible) positions, and the merged bedMethyl retains no record of how many inputs contributed, so this cannot be filtered downstream. Doing it inside `merge` is natural and efficient because the merge already reads each input per region via the tabix index. See the linked issue for details.

## Implementation

In `merge_data` (`modkit-core/src/bedmethyl_util/subcommands.rs`) the per-region accumulator changes from `FxHashMap<Key, BedMethylLine>` to `FxHashMap<Key, (BedMethylLine, usize)>`, where the `usize` tallies how many inputs contributed to that `Key` (each input has at most one record per key). A record below `--min-sample-coverage` is skipped (so it counts toward neither the tally nor the sums). After accumulation, `into_values()` is filtered to entries whose tally `>= --min-samples`. The CLI args are validated in `run()` (`--min-samples >= 1`; a warning if it exceeds the number of inputs). No change to the region-wise, tabix-indexed, rayon-parallel structure.

## Docs

- `book/src/intro_bedmethyl_merge.md`: new "Requiring positions in multiple samples (inner join)" section with examples.
- `book/src/advanced_usage.md`: regenerated (only the `bedmethyl merge` section changed).
- `CHANGELOG.md`: `[Unreleased] -> Adds` entry.

## Testing

**Unit/integration tests** (`modkit/tests/test_bedmethyl_util.rs`) — `cargo test -p modkit --test test_bedmethyl_util`, 4/4 pass:
- existing `test_bedmethyl_merge` (backward-compat, unchanged) — still passes;
- `--min-samples 2` over the same input twice keeps all shared positions;
- `--min-samples 3` over two inputs drops everything (insufficient samples);
- a high `--min-sample-coverage` excludes all records.

**Build** — both profiles pass on Ubuntu with the default (pure-Rust `burn`/`ndarray`) backend, no libtorch required:
- `cargo build` (debug) — OK
- `cargo build --release` — OK
- `cargo fmt` applied to the changed files.

**Real data** — merge of three ONT DRS replicate bedMethyl files (~120M rows each), transcriptome-aligned:
Below timings are from a debug binary.
```
=== backward-compat: --min-samples 1 (outer) ===
  elapsed: 1128s
=== inner join: --min-samples 3 --min-sample-coverage 5 ===
  elapsed: 1041s
=== record counts ===
  --min-samples 1 (outer)            : 143592975
  --min-samples 3 --min-sample-cov 5 : 81647746
  inner / outer retained             : 56.86%
=== cross-check: existing pipeline outer merge record count (modkit 0.6.3 release) ===
  existing d0_merged.bed.gz          : 143592975
  (should equal --min-samples 1 count: 143592975)
```