### PR TITLE
Clear generic pileup state between records

### DIFF
--- a/modkit-core/src/pileup/pileup_processor.rs
+++ b/modkit-core/src/pileup/pileup_processor.rs
@@ -2495,6 +2495,11 @@ fn update_mods_iter2<'a>(
                 return Err(MkError::HtsLibError(e));
             }
         }
+    } else {
+        *mod_pos = None;
+        *canonical_base = None;
+        *pos_base_mod_call = None;
+        *mod_strand = None;
     }
     Ok(())
 }
@@ -2506,4 +2511,99 @@ fn indices_to_byte(motif_idxs: &BitSlice) -> u8 {
         agg |= b << i;
     }
     agg
+}
+
+#[cfg(test)]
+mod tests {
+    use rust_htslib::bam::{
+        self,
+        header::HeaderRecord,
+        record::{Aux, Cigar, CigarString},
+    };
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn make_aligned_mod_record(
+        name: &[u8],
+        mm: &str,
+        ml: &[u8],
+    ) -> bam::Record {
+        let mut record = bam::Record::new();
+        record.set(
+            name,
+            Some(&CigarString(vec![Cigar::Match(5)])),
+            b"AAAAA",
+            &[255; 5],
+        );
+        record.set_tid(0);
+        record.set_pos(0);
+        record.set_mapq(60);
+        record.push_aux(b"MM", Aux::String(mm)).unwrap();
+        record.push_aux(b"ML", Aux::ArrayU8(ml.into())).unwrap();
+        record
+    }
+
+    #[test]
+    fn generic_pileup_clears_mod_state_between_records() {
+        let temp_dir = tempdir().unwrap();
+        let bam_path = temp_dir.path().join("two-records.bam");
+        let mut header = bam::Header::new();
+        let mut hd = HeaderRecord::new(b"HD");
+        hd.push_tag(b"VN", "1.6").push_tag(b"SO", "coordinate");
+        header.push_record(&hd);
+        let mut sq = HeaderRecord::new(b"SQ");
+        sq.push_tag(b"SN", "chr1").push_tag(b"LN", 5);
+        header.push_record(&sq);
+
+        {
+            let mut writer =
+                bam::Writer::from_path(&bam_path, &header, bam::Format::Bam)
+                    .unwrap();
+            writer
+                .write(&make_aligned_mod_record(b"modified", "A+a.,4;", &[255]))
+                .unwrap();
+            writer
+                .write(&make_aligned_mod_record(b"canonical", "A+a.;", &[]))
+                .unwrap();
+        }
+        bam::index::build(&bam_path, None, bam::index::Type::Bai, 1).unwrap();
+
+        let mut worker = GenericPileupWorker::new(
+            &bam_path,
+            None,
+            Vec::new(),
+            0.0,
+            [0.0; 4],
+            &[],
+            PileupNumericOptions::Passthrough,
+            false,
+            u16::MAX,
+        )
+        .unwrap();
+        let coordinates =
+            ChromCoordinates::new(0, 0, 5, FocusPositions2::AllPositions, true);
+        let pileup =
+            worker.process(coordinates, ModBasePileup2::new_empty()).unwrap();
+        let counts = pileup
+            .position_feature_counts
+            .iter()
+            .find(|counts| {
+                counts.position == 4 && counts.mod_code == SIX_METHYL_ADENINE
+            })
+            .unwrap();
+
+        assert_eq!(counts.filtered_coverage, 2);
+        assert_eq!(counts.n_modified, 1);
+        assert_eq!(counts.n_canonical, 1);
+        assert_eq!(counts.n_other_modified, 0);
+        assert_eq!(counts.n_delete, 0);
+        assert_eq!(counts.n_filtered, 0);
+        assert_eq!(counts.n_diff, 0);
+        assert_eq!(counts.n_nocall, 0);
+        assert_eq!(
+            f32::from(counts.n_modified) / f32::from(counts.filtered_coverage),
+            0.5
+        );
+    }
 }


### PR DESCRIPTION
Fixes #647.

## Summary

- Clear all cached modification fields when the generic pileup modification iterator is exhausted.
- Prevent a preceding read's modification call from being attributed to a following empty-MM read.
- Add a worker-level two-record regression for the populated-to-empty state transition.

## Severity

**Severity: High — scientific correctness**

**Rationale:** The affected path exits successfully but can silently inflate modified counts and reduce canonical counts in bedMethyl output.

## Root cause

`update_mods_iter2` populated `mod_pos`, `canonical_base`, `pos_base_mod_call`, and `mod_strand` when the iterator yielded a call, but left all four fields unchanged when it returned `None`. The generic worker could therefore reuse state from the preceding record.

## Implementation

Clear all four cached fields on iterator exhaustion. The regression drives the actual generic worker with one explicit modified-A read followed by an implicit-mode read with an empty MM group at the same coordinate.

### Preserved behavior

- Existing behavior is unchanged while the iterator contains a call.
- Coverage and all unrelated count categories remain unchanged.
- No output schema or CLI option changes.

### Non-goals

- Does not redesign MM/ML parsing or generic-pileup storage.
- Does not change optimized or high-depth pileup paths.
- Does not include a performance refactor.

## Behavior before and after

| Case | Before | After | Expected oracle |
|---|---|---|---|
| Modified read followed by empty-MM read at position 4 | 2 modified, 0 canonical, 100.00% | 1 modified, 1 canonical, 50.00% | Coverage 2 partitioned exactly 1/1 |
| Other count categories | All zero | All zero | Unchanged |

## Testing

**Test environment**

- Revision tested: `948830d4e44d1be8aedadce810d1ca8068397c3a`
- Tree tested and worktree state: `f0fd371c4bd0fdb6b13893c94b96fcd581748a17`; clean at final verification
- Platform: macOS on Apple silicon
- Reference binary: installed modkit 0.6.4
- Exact Rust and samtools versions were not retained in the original test log.
- Dependency resolution: existing workspace manifests; no dependency or lockfile change in this PR

| Test layer | Exact command, fixture, or matrix | Result and evidence |
|---|---|---|
| **Core: parent-red regression** | Focused worker regression applied to base `5cecc3fb3a9336068d9e3c68d5c08d678153dd2c` | Failed as expected with `n_modified = 2` instead of 1 |
| **Core: focused regression** | `cargo test -p mod_kit generic_pileup_clears_mod_state_between_records --lib` | Passed |
| Unit/library tests | `cargo test -p mod_kit --lib` | 96 passed, 3 ignored, 0 failed |
| **Core: affected CLI comparison** | Installed 0.6.4 and patched CLI on the two-record issue fixture | Only the final position changed from `100.00 / 2 / 0` to `50.00 / 1 / 1` |
| **Core: applicable full workspace gate** | `cargo test --workspace --quiet` | Passed; the aggregate count was not retained in the original log |
| **Core: formatting/diff checks** | `rustfmt --check --edition 2021 modkit-core/src/pileup/pileup_processor.rs`; `git diff --check` | Passed |
| Additional formatting check | `cargo fmt --all -- --check` | Reported pre-existing unrelated differences in `modkit/tests/test_bedmethyl_util.rs`, `modkit-core/src/adjust.rs`, and `modkit-core/src/entropy/mod.rs`; the changed file itself passed rustfmt |

### Tests not performed

- No large real-data or performance/RSS benchmark was run; this change adds only constant-time field clearing on iterator exhaustion and the exact synthetic oracle covers the scientific behavior.
- No CRAM-specific matrix was run because the defect is downstream of record decoding and format-independent.

## Scientific validation

- **Count conservation:** Coverage 2 equals one modified plus one canonical observation.
- **Coordinate invariant:** Only reference position 4 changes.
- **Category invariant:** Filtered, deletion, fail, difference, no-call, and other counts remain zero.
- **Independent oracle:** Per-read MM semantics were reviewed independently; the expected fraction is exactly 1/2.

## Output and compatibility

- User-visible change is limited to correcting affected generic-pileup counts.
- Output schema, ordering, and CLI compatibility are unchanged.
- Unaffected records remain byte-identical in the fixture comparison.

## Reviewer guide

1. Review the two-record worker regression and its 1/1 count oracle.
2. Review the exhausted-iterator branch in `update_mods_iter2`.
3. Rerun `cargo test -p mod_kit generic_pileup_clears_mod_state_between_records --lib`.
4. Confirm the one-file production change is limited to clearing per-record state.

## Checklist

- [x] Linked issue contains reproducible observed and expected behavior.
- [x] Change is limited to the linked issue's scope.
- [x] Regression is red on the parent and green on this revision.
- [x] All tests performed are listed with their results.
- [x] Unrun applicable tests are disclosed.
- [x] Scientific count conservation and output compatibility are checked.
- [x] Changed-file formatting and diff hygiene pass.
