### PR TITLE
Exclude unmapped calls from CpG summaries

### DIFF
--- a/modkit-core/src/modbam_util/subcommands.rs
+++ b/modkit-core/src/modbam_util/subcommands.rs
@@ -1932,7 +1932,11 @@ impl ModSummarize {
                 multi_progress.clone(),
             )?;
 
-            if self.mapped_only || self.matched_only || self.motif.is_some() {
+            if self.mapped_only
+                || self.matched_only
+                || self.motif.is_some()
+                || self.cpg
+            {
                 qual_hist
             } else if let Some(nr) = self.num_reads {
                 if qual_hist.ok_records < nr {

--- a/modkit/tests/test_summary.rs
+++ b/modkit/tests/test_summary.rs
@@ -5,10 +5,83 @@ use crate::common::{
 use anyhow::Context;
 use mod_kit::mod_bam::{CollapseMethod, EdgeFilter};
 use mod_kit::mod_base_code::{BaseState, DnaBase};
-use std::collections::HashSet;
+use rust_htslib::bam::{self, record::Aux, Read};
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
 
 mod common;
+
+fn run_cpg_summary(bam_fp: &Path) -> HashMap<String, String> {
+    let output = Command::new(env!("CARGO_BIN_EXE_modkit"))
+        .args([
+            "summary",
+            bam_fp.to_str().unwrap(),
+            "--reference",
+            "../tests/resources/CGI_ladder_3.6kb_ref.fa",
+            "--cpg",
+            "--filter-threshold",
+            "0",
+            "--tsv",
+            "--suppress-progress",
+            "--threads",
+            "1",
+            "--io-threads",
+            "1",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "summary failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| {
+            let (key, value) = line.split_once('\t').unwrap();
+            (key.to_string(), value.to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn test_summary_cpg_excludes_unmapped_calls() {
+    let mapped_bam =
+        Path::new("../tests/resources/bc_anchored_10_reads.sorted.bam");
+    let temp_dir = tempdir().unwrap();
+    let mixed_bam = temp_dir.path().join("mapped-and-unmapped.bam");
+    let mut reader = bam::Reader::from_path(mapped_bam).unwrap();
+    let header = bam::Header::from_template(reader.header());
+    let mut writer =
+        bam::Writer::from_path(&mixed_bam, &header, bam::Format::Bam).unwrap();
+    for record in reader.records() {
+        writer.write(&record.unwrap()).unwrap();
+    }
+
+    let mut unmapped = bam::Record::new();
+    unmapped.set(b"unmapped", None, b"CCCC", &[255; 4]);
+    unmapped.set_unmapped();
+    unmapped.set_tid(-1);
+    unmapped.set_pos(-1);
+    unmapped.set_mtid(-1);
+    unmapped.set_mpos(-1);
+    unmapped.push_aux(b"MM", Aux::String("C+m?,0,0,0,0;")).unwrap();
+    unmapped.push_aux(b"ML", Aux::ArrayU8((&[255; 4][..]).into())).unwrap();
+    unmapped.push_aux(b"MN", Aux::I32(4)).unwrap();
+    writer.write(&unmapped).unwrap();
+    drop(writer);
+    bam::index::build(&mixed_bam, None, bam::index::Type::Bai, 1).unwrap();
+
+    let mixed_summary = run_cpg_summary(&mixed_bam);
+    let mapped_summary = run_cpg_summary(mapped_bam);
+    assert_eq!(mixed_summary["total_reads_used"], "10");
+    assert_eq!(mixed_summary["count_reads_C"], "10");
+    assert_eq!(mixed_summary["C_total_mod_calls"], "77");
+    assert_eq!(mixed_summary, mapped_summary);
+}
 
 /// tests that the summary from a BAM is the same if run with the BAI
 /// or without (just taking the first N reads). In this case we use all


### PR DESCRIPTION
Fixes #649.

## Summary

- Exclude unmapped records from indexed `summary --cpg` results, matching the documented `--motif CG 0` behavior.
- Preserve the mapped CpG histogram and Summary schema.
- Add an end-to-end CLI regression containing a valid unmapped MM/ML/MN record.

## Severity

**Severity: High — scientific correctness**

**Rationale:** The shorthand can silently include an ineligible unmapped population and alter read totals and modification statistics while the command exits successfully.

## Root cause

The indexed Summary path correctly constructs a `CG` motif for `--cpg`, but the later guard that skips unmapped collection checked only `mapped_only`, `matched_only`, and an explicit `motif`. Omitting the CpG shorthand allowed all unmapped calls to be merged into the mapped reference-CpG histogram.

## Implementation

Treat `--cpg` as a resolved motif restriction in the unmapped-collection guard. The regression copies the 10 mapped test records and appends an unmapped `CCCC` record with `MM:Z:C+m?,0,0,0,0;`, four ML values of 255, and `MN:i:4`, then compares normalized CLI output with mapped-only and explicit-motif controls.

### Preserved behavior

- Mapped CpG motif matching and thresholds are unchanged.
- Summary keys, category definitions, and output schema are unchanged.
- Explicit `--motif CG 0` behavior remains unchanged.

### Non-goals

- Does not change mapped motif lookup.
- Does not change fractional/fixed-count sampling or automatic thresholds.
- Does not redefine modification classes or other unmapped-record modes.

## Behavior before and after

| Case | Before | After | Expected oracle |
|---|---|---|---|
| Mixed 10-mapped/10-unmapped issue fixture under `--cpg` | 20 reads, 186 C calls | 10 reads, 77 C calls | Equal to `--motif CG 0` and mapped-only control |
| Focused test with one appended unmapped record | `total_reads_used=11` | `total_reads_used=10` | Unmapped record contributes no Summary category |

## Testing

**Test environment**

- Revision tested: `a99f411a8dacfd4bf705fc9adb068219bc7bafc7`
- Tree tested and worktree state: `0b532f8ee0fd65de5e489f32485792209182112f`; clean at final verification
- Platform: macOS on Apple silicon
- Reference binary: installed modkit 0.6.4
- External tool: samtools 1.23.1 for fixture construction
- Exact Rust version was not retained in the original test log.
- Dependency resolution: existing workspace manifests; no dependency or lockfile change in this PR

| Test layer | Exact command, fixture, or matrix | Result and evidence |
|---|---|---|
| **Core: parent-red regression** | Final focused test applied to base `5cecc3fb3a9336068d9e3c68d5c08d678153dd2c` | Failed as expected: `total_reads_used=11` instead of 10 |
| **Core: focused regression** | `cargo test -p modkit --test test_summary test_summary_cpg_excludes_unmapped_calls -- --exact` | Passed |
| **Core: affected integration tests** | `cargo test -p modkit --test test_summary` | 5 passed, 0 failed |
| Neighboring pileup integration | `cargo test -p modkit --test test_pileup -- --test-threads=1` | 16 passed, 10 ignored, 0 failed |
| **Core: applicable full workspace gate** | `cargo test --workspace --quiet -- --test-threads=1` | Passed; aggregate count was not retained in the original log |
| Installed-versus-fixed comparison | Issue fixture under `--cpg`, explicit `--motif CG 0`, and mapped-only control | `20 / 186` becomes `10 / 77` and matches both controls |
| **Core: formatting/diff checks** | `rustfmt --check --edition 2021 modkit-core/src/modbam_util/subcommands.rs modkit/tests/test_summary.rs`; `git diff --check` | Passed |
| Disclosed initial test failure | Initial default-parallel package run; exact invocation was not retained | Failed because existing `test_pileup_no_filt` and `test_pileup_with_header` share `/tmp/test_pileup_nofilt.bed`; serial affected and workspace gates pass, and this PR does not touch pileup |

### Tests not performed

- No performance/RSS benchmark was run; the production change adds one boolean term outside the per-call hot path.
- No large real-data or CRAM matrix was run; the exact mixed indexed-BAM fixture directly exercises the affected branch.

## Scientific validation

- **Population invariant:** Reference-CpG summaries contain only records assignable to a reference motif.
- **Equivalence invariant:** `--cpg` equals explicit `--motif CG 0` after normalizing key order.
- **Count invariant:** The unmapped record changes neither read totals nor canonical/modified categories.
- **Independent oracle:** The mapped-only fixture and explicit motif command independently produce 10 reads and 77 C calls.

## Output and compatibility

- Only the incorrect unmapped contribution is removed.
- Summary schema and mapped-record behavior are unchanged.
- The documented shorthand becomes behaviorally consistent with its explicit form.

## Reviewer guide

1. Review the mixed mapped/unmapped CLI regression and its two independent controls.
2. Review the one-condition change in the indexed Summary unmapped guard.
3. Rerun `cargo test -p modkit --test test_summary test_summary_cpg_excludes_unmapped_calls -- --exact`.
4. Rerun `cargo test -p modkit --test test_summary` as the affected integration canary.

## Checklist

- [x] Linked issue contains reproducible observed and expected behavior.
- [x] Change is limited to the linked issue's scope.
- [x] Regression is red on the parent and green on this revision.
- [x] All tests performed, including the unrelated initial failure, are disclosed.
- [x] Unrun applicable tests are disclosed.
- [x] Scientific population/count invariants and compatibility are checked.
- [x] Changed-file formatting and diff hygiene pass.
