### PR TITLE
Apply localize minimum coverage before aggregation

### DIFF
--- a/modkit-core/src/localise/subcommand.rs
+++ b/modkit-core/src/localise/subcommand.rs
@@ -271,6 +271,7 @@ impl EntryLocalize {
                 .map(|gr| {
                     gr.into_localized_mod_counts(
                         &tabix_index,
+                        min_cov,
                         self.stranded_features,
                         stranded_features,
                         self.io_threads,

--- a/modkit-core/src/localise/util.rs
+++ b/modkit-core/src/localise/util.rs
@@ -190,6 +190,7 @@ impl GenomeRegion {
     pub(super) fn into_localized_mod_counts(
         self,
         index: &HtsTabixHandler<BedMethylLine>,
+        min_coverage: u64,
         strand_rule: Option<StrandRule>,
         stranded_features: Option<StrandedFeatures>,
         io_threads: usize,
@@ -203,6 +204,7 @@ impl GenomeRegion {
         let anchor_point = self.midpoint();
         let loc_counts = bedmethyl_records
             .into_par_iter()
+            .filter(|bm| bm.valid_coverage >= min_coverage)
             .filter(|bm| {
                 stranded_features
                     .map(|f| {

--- a/modkit/tests/test_localize.rs
+++ b/modkit/tests/test_localize.rs
@@ -1,4 +1,6 @@
 use crate::common::run_modkit;
+use std::fs;
+use tempfile::tempdir;
 
 mod common;
 
@@ -8,4 +10,50 @@ fn test_localise_helps() {
         .expect("failed to run modkit localize help");
     let _ = run_modkit(&["localise", "--help"])
         .expect("failed to run modkit localise help");
+}
+
+#[test]
+fn test_localize_min_coverage_filters_before_aggregation() {
+    let temp_dir = tempdir().unwrap();
+    let regions = temp_dir.path().join("regions.bed");
+    let genome_sizes = temp_dir.path().join("genome-sizes.tsv");
+    fs::write(&regions, "chr20\t9681998\t9681999\nchr20\t9838537\t9838538\n")
+        .unwrap();
+    fs::write(&genome_sizes, "chr20\t64444167\n").unwrap();
+
+    let run = |min_coverage: u64| {
+        let output = temp_dir.path().join(format!("min-{min_coverage}.tsv"));
+        let min_coverage = min_coverage.to_string();
+        run_modkit(&[
+            "localize",
+            "../tests/resources/lung_00733-m_adjacent-normal_5mc-5hmc_chr20_cpg_pileup.bed.gz",
+            "--regions",
+            regions.to_str().unwrap(),
+            "--genome-sizes",
+            genome_sizes.to_str().unwrap(),
+            "--window",
+            "1",
+            "--min-coverage",
+            &min_coverage,
+            "--threads",
+            "1",
+            "--io-threads",
+            "1",
+            "--out-file",
+            output.to_str().unwrap(),
+        ])
+        .unwrap();
+        fs::read_to_string(output).unwrap().replace("\r\n", "\n")
+    };
+
+    assert_eq!(
+        run(1),
+        "mod_code\toffset\tn_valid\tn_mod\tpercent_modified\n\
+         C\t-1\t24\t3\t12.5\n"
+    );
+    assert_eq!(
+        run(3),
+        "mod_code\toffset\tn_valid\tn_mod\tpercent_modified\n\
+         C\t-1\t23\t2\t8.695652\n"
+    );
 }


### PR DESCRIPTION
Fixes #651.

## Summary

- Pass `--min-coverage` into localize record processing.
- Retain each bedMethyl record only when `valid_coverage >= min_coverage`, before offset aggregation.
- Add an exact end-to-end CLI regression covering below, equal-to, and above-threshold records.

## Severity

**Severity: High — scientific correctness**

**Rationale:** The accepted option previously had no effect, silently allowing excluded low-coverage records to change localized scientific counts and percentages.

## Root cause

`EntryLocalize::run` assigned and logged `self.min_coverage` but did not pass it into `GenomeRegion::into_localized_mod_counts`. The aggregation therefore folded every fetched bedMethyl row into `n_valid` and `n_mod` regardless of the requested threshold.

## Implementation

Pass the minimum coverage into localized counting and filter each bedMethyl record before aggregation using the inclusive predicate `valid_coverage >= min_coverage`. The CLI regression uses two records that aggregate into the same output bin, with `(valid coverage, modified count)` values `(1,1)` and `(23,2)`.

### Preserved behavior

- Records equal to the threshold remain included.
- Aggregation, output ordering, and schema are unchanged after eligibility filtering.
- Default behavior is unchanged for records meeting the default threshold.

### Non-goals

- Does not change localize anchor, window, or offset conventions.
- Does not define or implement `--batch-size` behavior.
- Does not change chart rendering or regional worker-error handling.

## Behavior before and after

| Case | Before | After | Expected oracle |
|---|---|---|---|
| `--min-coverage 1` | 24 valid / 3 modified / 12.5% | Same | Both records meet the inclusive threshold |
| `--min-coverage 3` | 24 valid / 3 modified / 12.5% | 23 valid / 2 modified / 8.695652% | Coverage-1 record excluded before aggregation |

## Testing

**Test environment**

- Revision tested: `57c61c561a44addafe04f9b44dfd6de01cff5f95`
- Tree tested and worktree state: `e476b271f2bba441f9933c1894a16bf7b5d51096`; clean at final verification
- Platform: macOS on Apple silicon
- Reference binary: installed modkit 0.6.4
- Exact Rust and tabix versions were not retained in the original test log.
- Dependency resolution: existing workspace manifests; no dependency or lockfile change in this PR

| Test layer | Exact command, fixture, or matrix | Result and evidence |
|---|---|---|
| **Core: parent-red regression** | Final CLI regression applied to base `5cecc3fb3a9336068d9e3c68d5c08d678153dd2c` | Failed as expected: threshold 3 still produced `24 / 3 / 12.5` instead of `23 / 2 / 8.695652` |
| **Core: focused regression** | `cargo test -p modkit --test test_localize test_localize_min_coverage_filters_before_aggregation -- --exact` | Passed |
| **Core: affected integration tests** | `cargo test -p modkit --test test_localize` | 2 passed, 0 failed |
| **Core: applicable full workspace gate** | `cargo test --workspace --quiet -- --test-threads=1` | Passed; aggregate count was not retained in the original log |
| Installed-versus-fixed comparison | Issue fixture at thresholds 1 and 3 | Installed outputs are identical; fixed output changes only threshold 3 to the exact 23/2/8.695652 oracle |
| **Core: formatting/diff checks** | `rustfmt --check --edition 2021 modkit-core/src/localise/subcommand.rs modkit-core/src/localise/util.rs modkit/tests/test_localize.rs`; `git diff --check` | Passed |

The serial workspace mode avoids an existing unrelated collision between pileup integration tests that share a temporary output filename.

### Tests not performed

- No performance/RSS benchmark was run; the change adds one scalar comparison per fetched bedMethyl record.
- No large real-data regression was run; the two-record fixture distinguishes per-record filtering from an incorrect post-aggregation filter exactly.

## Scientific validation

- **Eligibility invariant:** A record contributes if and only if `valid_coverage >= min_coverage`.
- **Aggregation invariant:** Filtering occurs before records sharing an output offset are combined.
- **Count conservation:** Threshold 1 sums `(1,1)+(23,2)` to `(24,3)`; threshold 3 retains `(23,2)` only.
- **Independent oracle:** Direct inspection with tabix supplies the two source coverage/count pairs.

## Output and compatibility

- Only rows below the requested threshold are removed from aggregates.
- TSV schema, offset ordering, and CLI syntax are unchanged.
- Threshold-boundary records remain included.

## Reviewer guide

1. Review the two-record CLI fixture and its pre-aggregation oracle.
2. Review the threshold plumbing into `GenomeRegion::into_localized_mod_counts`.
3. Rerun `cargo test -p modkit --test test_localize test_localize_min_coverage_filters_before_aggregation -- --exact`.
4. Rerun `cargo test -p modkit --test test_localize` as the affected integration canary.

## Checklist

- [x] Linked issue contains reproducible observed and expected behavior.
- [x] Change is limited to the linked issue's scope.
- [x] Regression is red on the parent and green on this revision.
- [x] All tests performed are listed with their results.
- [x] Unrun applicable tests are disclosed.
- [x] Scientific eligibility/count invariants and compatibility are checked.
- [x] Changed-file formatting and diff hygiene pass.
