### PR TITLE
Map bedMethyl intervals and strands into genomic space

### DIFF
--- a/modkit-core/src/bedmethyl_util/subcommands.rs
+++ b/modkit-core/src/bedmethyl_util/subcommands.rs
@@ -24,6 +24,7 @@ use crate::command_utils::calculate_chunk_size;
 use crate::dmr::bedmethyl::BedMethylLine;
 use crate::dmr::isoform::{
     parse_gtf, transcript_pos0_to_genomic0, GtfId, GtfTranscript,
+    TranscriptModel,
 };
 use crate::errs::MkError;
 use crate::interval_chunks::{
@@ -696,6 +697,26 @@ pub struct EntryMapToGenome {
     header: bool,
 }
 
+fn map_bedmethyl_line_to_genome(
+    tm: &TranscriptModel,
+    mut bml: BedMethylLine,
+) -> Result<BedMethylLine, MkError> {
+    let genome_start = transcript_pos0_to_genomic0(tm, bml.start())?;
+    let genome_stop =
+        genome_start.checked_add(1).ok_or(MkError::InvalidGenomicPosition)?;
+    bml.strand = match (tm.strand(), bml.strand) {
+        ('+', strand) => strand,
+        ('-', StrandRule::Positive) => StrandRule::Negative,
+        ('-', StrandRule::Negative) => StrandRule::Positive,
+        ('-', StrandRule::Both) => StrandRule::Both,
+        _ => return Err(MkError::InvalidStrand),
+    };
+
+    bml.chrom = tm.chrom.clone();
+    bml.interval = Iv { start: genome_start, stop: genome_stop, val: () };
+    Ok(bml)
+}
+
 impl EntryMapToGenome {
     pub fn run(&self) -> anyhow::Result<()> {
         let _ = init_logging(None);
@@ -750,7 +771,7 @@ impl EntryMapToGenome {
 
         reader.fetch(tid, 0, tm.transcript_len)?;
         for res in reader.records() {
-            let Ok(mut bml) = res
+            let Ok(bml) = res
                 .map_err(|e| MkError::HtsLibError(e))
                 .and_then(|bs| {
                     String::from_utf8(bs)
@@ -761,22 +782,10 @@ impl EntryMapToGenome {
                 errored.inc(1);
                 continue;
             };
-            let Ok(genome_start) =
-                transcript_pos0_to_genomic0(&tm, bml.start())
-            else {
+            let Ok(bml) = map_bedmethyl_line_to_genome(tm, bml) else {
                 errored.inc(1);
                 continue;
             };
-            let genome_stop = match bml.strand {
-                StrandRule::Positive | StrandRule::Both => {
-                    genome_start.saturating_add(1)
-                }
-                StrandRule::Negative => genome_start.saturating_sub(1),
-            };
-
-            bml.chrom = tm.chrom.clone();
-            bml.interval =
-                Iv { start: genome_start, stop: genome_stop, val: () };
             writer.write(bml.to_line().as_bytes())?;
             processed_records.inc(1);
         }
@@ -790,5 +799,87 @@ impl EntryMapToGenome {
         });
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+    use crate::util::StrandRule::{Both, Negative, Positive};
+
+    fn bedmethyl_at(
+        transcript_id: &str,
+        position: u64,
+        strand: StrandRule,
+    ) -> BedMethylLine {
+        BedMethylLine::new(
+            transcript_id.to_string(),
+            Iv { start: position, stop: position + 1, val: () },
+            ModCodeRepr::Code('m'),
+            strand,
+            1,
+            2,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+        )
+    }
+
+    #[test]
+    fn map_to_genome_composes_coordinates_and_strands() {
+        let mut gtf = NamedTempFile::new().unwrap();
+        write!(
+            gtf,
+            concat!(
+                "chrP\ttest\texon\t1\t2\t.\t+\t.\tgene_id \"g_pos\"; transcript_id \"tx_pos\";\n",
+                "chrP\ttest\texon\t11\t12\t.\t+\t.\tgene_id \"g_pos\"; transcript_id \"tx_pos\";\n",
+                "chrN\ttest\texon\t1\t2\t.\t-\t.\tgene_id \"g_neg\"; transcript_id \"tx_neg\";\n",
+                "chrN\ttest\texon\t11\t12\t.\t-\t.\tgene_id \"g_neg\"; transcript_id \"tx_neg\";\n",
+            )
+        )
+        .unwrap();
+
+        let multi_progress = MultiProgress::new();
+        multi_progress.set_draw_target(ProgressDrawTarget::hidden());
+        let models = parse_gtf(gtf.path(), true, &multi_progress).unwrap();
+        let cases = [
+            ("tx_pos", 0, Positive, "chrP", 0, Positive),
+            ("tx_pos", 1, Negative, "chrP", 1, Negative),
+            ("tx_pos", 2, Positive, "chrP", 10, Positive),
+            ("tx_pos", 3, Negative, "chrP", 11, Negative),
+            ("tx_neg", 0, Positive, "chrN", 11, Negative),
+            ("tx_neg", 1, Negative, "chrN", 10, Positive),
+            ("tx_neg", 2, Positive, "chrN", 1, Negative),
+            ("tx_neg", 3, Negative, "chrN", 0, Positive),
+            ("tx_neg", 0, Both, "chrN", 11, Both),
+        ];
+
+        for (tx_id, tx_pos, input_strand, chrom, genome_start, output_strand) in
+            cases
+        {
+            let tx_key = GtfTranscript::new(tx_id.to_string(), 0);
+            let model = models.get(&tx_key).unwrap();
+            let mapped = map_bedmethyl_line_to_genome(
+                model,
+                bedmethyl_at(tx_id, tx_pos, input_strand),
+            )
+            .unwrap();
+            assert_eq!(
+                (
+                    mapped.chrom.as_str(),
+                    mapped.start(),
+                    mapped.stop(),
+                    mapped.strand,
+                ),
+                (chrom, genome_start, genome_start + 1, output_strand)
+            );
+        }
     }
 }

--- a/modkit-core/src/dmr/isoform/mod.rs
+++ b/modkit-core/src/dmr/isoform/mod.rs
@@ -154,6 +154,12 @@ pub(crate) struct TranscriptModel {
     pub transcript_len: u64,   // total spliced transcript length
 }
 
+impl TranscriptModel {
+    pub(crate) fn strand(&self) -> char {
+        self.strand
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct GeneCommonCoord {
     pub gene_id: GtfGene,


### PR DESCRIPTION
**Review status: Author-reviewed and ready for ONT review.**

Fixes #661.

## Summary

- Always emit valid half-open single-base genomic intervals from `bedmethyl map-to-genome`.
- Compose transcript-relative bedMethyl strands with the GTF transcript strand.
- Add an exact coordinate/strand matrix spanning positive and negative two-exon transcripts, coordinate zero, exon boundaries, both row strands, and unstranded rows.

## Severity

**Severity:** High — scientific correctness and output validity

**Rationale:** The affected command exits successfully while producing reversed intervals and incorrect genomic strand labels, which can cause downstream interval tools to reject or biologically misinterpret rows.

## Root cause

The map-to-genome loop used the input bedMethyl strand to choose the coordinate endpoint, subtracting one for a negative row. Strand is an annotation and must not determine BED interval direction. The loop also changed the contig and coordinate but never composed the transcript-relative row strand with the transcript model's genomic orientation.

## Implementation

- Introduce `map_bedmethyl_line_to_genome`, which converts the transcript start with the existing exon-aware mapper, obtains the stop with checked `+1`, composes strand, and updates the output contig/interval together.
- Add a crate-private `TranscriptModel::strand()` accessor, keeping other model details encapsulated.
- Route the CLI loop through the helper and preserve the existing per-record error/skip boundary.
- Add one table-driven unit test with nine exact cases across both transcript orientations, exon boundaries, coordinate zero, `+`, `-`, and `.`.

### Preserved behavior

- Transcript parsing, ID/version selection, input iteration, row ordering, headers, numeric count fields, and per-record error handling are unchanged.
- Positive-transcript row strands are unchanged.
- Negative-transcript output remains in existing transcript/input order rather than being genomically resorted.

### Non-goals

- No change to transcript-contig prefix matching or output sorting.
- No new validation policy for malformed/non-unit input records.
- No merge, DMR, sampling, schema, or performance change.

## Behavior before and after

| Case | Before | After | Expected oracle |
|---|---|---|---|
| Negative row on positive transcript at genomic start 1 | `[1,0)`, strand `-` | `[1,2)`, strand `-` | Single-base interval; positive transcript preserves strand |
| Positive row at transcript position 0 on negative transcript | `[11,12)`, strand `+` | `[11,12)`, strand `-` | Negative transcript flips strand |
| Negative row at transcript position 1 on negative transcript | `[10,9)`, strand `-` | `[10,11)`, strand `+` | Single-base interval and flipped strand |
| Unstranded row on negative transcript | Valid interval, strand `.` | Valid interval, strand `.` | Unstranded remains unstranded |

## Testing

**Test environment**

- Revision tested: `ab28f5f86a27259db35310308f80329af4736fb6`
- Tree tested and worktree state: `788fdf37cb56da054f553393804dd53c33cd9e2b`; clean
- Parent revision: `5cecc3fb3a9336068d9e3c68d5c08d678153dd2c`
- Toolchain: rustc 1.90.0; cargo 1.90.0
- Platform: macOS 26.6, arm64
- Reference binary: installed modkit 0.6.4
- External tools: bgzip/tabix from HTSlib 1.23.1
- Dependency resolution identity: ignored test-only `Cargo.lock` SHA-256 `49c08c4c51b6f4320726551146d971fa9ef2183d40c3f6c631b2005965e242c0`; resolved `hts-sys 2.2.0`; the lockfile is not in this diff

| Test layer | Exact command, fixture, or matrix | Result and evidence |
|---|---|---|
| **Core: parent-red regression** | Synthetic GTF and indexed bedMethyl commands from the linked issue on installed modkit 0.6.4 | Exit 0 with `[1,0)` and `[10,9)` invalid intervals; both negative-transcript strands remain transcript-relative |
| **Core: focused regression** | `cargo test --offline --locked -p mod_kit bedmethyl_util::subcommands::tests::map_to_genome_composes_coordinates_and_strands -- --exact --test-threads=1` | 1 passed, 0 failed; nine coordinate/strand cases asserted |
| Unit/library tests | `cargo test --offline --locked -p mod_kit -- --test-threads=1` | 96 passed, 3 declared ignored, 0 failed |
| **Core: affected CLI/integration tests** | `cargo test --offline --locked -p modkit --test test_bedmethyl_util -- --test-threads=1` | 4 passed, 0 failed |
| **Core: applicable full workspace gate** | `cargo test --offline --workspace --all-targets -- --test-threads=1` on the frozen exact head | Every active workspace/all-target test passed with 0 failures in the recorded serial gate |
| Installed-versus-fixed comparison | Three-row public fixture from the linked issue | Positive output changed from SHA-256 `faec651a64d16ac971cf19b82321c3809dfa34d28e4f7977e78f3d276916e7ed` to `679f14e162ff8809d54d19b701f6d01543fa2400bcfed99316671b82d765170f`; negative output changed from `cc357b2588e711ecc4d84c2372e48f06abc0ce8aa8b945140b403687d8b3d7e6` to `f15c5dd598081bcf68215db175cf4337a98a202db962e019acd96eb67fc74f06` |
| Coordinate/strand matrix | Two exons per positive/negative transcript; transcript positions 0–3; row strands `+`, `-`, `.` | Exact contig/start/stop/strand tuples pass; every stop is start+1 |
| **Core: formatting/diff checks** | Direct `rustfmt --edition 2021 --check` on both changed Rust files; `git diff --check upstream/master...HEAD`; clean-worktree check | Passed; only stable-rustfmt warnings for nightly-only repository settings were emitted; worktree clean |

### Tests not performed

- The 1-GB direct-RNA slice was not run; the defect has a complete exact coordinate/strand oracle and does not touch BAM processing.
- Performance, RSS, and I/O benchmarks were not run because this is a local correctness-only transformation.
- `cargo clippy` was not run.

## Scientific validation

- Population/eligibility invariant: the same parsed input rows are processed or skipped; only genomic representation changes.
- Count/category conservation invariant: every bedMethyl count field is preserved exactly.
- Coordinate/strand/interval invariant: each mapped base is `[g, g+1)`; genomic strand is transcript strand composed with row strand.
- Determinism invariant: the mapping helper is pure for a transcript model and row; existing row order is preserved.
- Independent oracle or specialist review: coordinates and strand algebra were independently reviewed against GTF exon orientation and exact CLI outputs; no blocker remained.

## Output and compatibility

- User-visible change: affected rows now have valid genomic intervals and genomic strand labels.
- Expected output differences: only interval endpoints and negative-transcript strand labels in the affected cases.
- Byte-identical controls: count fields, modification code, coverage, score/color fields, positive-transcript strand labels, and row order remain unchanged.
- CLI/API/schema compatibility: unchanged; the new helper and accessor are crate-private.
- Partial-output or failure semantics: unchanged.

## Reviewer guide

1. Review `map_to_genome_composes_coordinates_and_strands` for the complete nine-case oracle.
2. Review `map_bedmethyl_line_to_genome` for checked interval construction and three-way strand composition.
3. Review the small crate-private transcript-strand accessor.
4. Confirm the CLI loop still owns the same record parse/skip behavior.
5. Rerun the focused test and the two short public CLI commands from the issue.

## Checklist

- [x] The issue contains reproducible observed and expected behavior.
- [x] The change is limited to the linked issue’s approved scope.
- [x] The regression is demonstrably red on the exact parent revision.
- [x] All tests actually performed are listed above with their results.
- [x] Unrun or inapplicable tests are disclosed.
- [x] Scientific counts/statistics and output compatibility are explicitly checked.
- [x] Formatting and diff-hygiene checks pass, or unrelated findings are documented.
- [x] No generated data, private sample identifiers, or unrelated changes are included.

