### PR TITLE
Pin hts-sys to bindings compatible with rust-htslib 0.46

### DIFF
--- a/modkit-core/Cargo.toml
+++ b/modkit-core/Cargo.toml
@@ -44,6 +44,8 @@ random_color = "1.0.0"
 rayon = "1.8.0"
 regex = "1.4"
 rust-htslib = "0.46.0"
+# rust-htslib 0.46 does not compile with the bindings shipped by hts-sys 2.2.1.
+hts-sys = "=2.2.0"
 rust-lapper = "1.1.0"
 rustc-hash = "1.1.0"
 rv = "=0.16.0"


### PR DESCRIPTION
**Review status: Author-reviewed and ready for ONT review.**

Fixes #665.

## Summary

- Constrain `hts-sys` to 2.2.0, whose bindings compile with the existing rust-htslib 0.46.0 dependency.
- Prevent fresh dependency resolution from selecting hts-sys 2.2.1 and breaking the workspace build.
- Keep the repair to one manifest constraint plus an explanatory comment; no Rust source or generated lockfile changes.

## Severity

**Severity:** High — build reproducibility and development reliability

**Rationale:** A clean checkout currently fails before modkit can be built or tested. The failure is explicit and cannot corrupt scientific output, but it blocks reproducible development, CI, packaging, and source installation.

## Root cause

The workspace does not commit `Cargo.lock`. rust-htslib 0.46.0 permits the semver-compatible hts-sys 2.x range beginning at 2.1.1, so a fresh solve now selects hts-sys 2.2.1. Its binding field names and integer types do not match rust-htslib 0.46.0's source, producing ten compile errors. Cargo had no repository-level constraint that retained the known-compatible 2.2.0 bindings.

## Implementation

Add `hts-sys = "=2.2.0"` immediately after rust-htslib in `modkit-core/Cargo.toml`, with a one-line reason. Because all rust-htslib users are in the same workspace graph, Cargo unifies them onto one hts-sys 2.2.0 instance.

### Preserved behavior

- rust-htslib remains at 0.46.0 and retains its existing default bzip2, lzma, and curl feature set.
- The dependency graph contains one hts-sys instance rather than parallel binding versions.
- No Rust source, CLI, file format, data path, test fixture, or scientific result changes.
- `Cargo.lock` remains ignored and absent from the diff.

### Non-goals

- No rust-htslib/HTSlib stack upgrade or broad dependency refresh.
- No decision to commit `Cargo.lock` or require `--locked` in future CI/install workflows.
- No bindgen/libclang enablement, generated binding changes, or patches to upstream crates.
- No new CI workflow.

## Behavior before and after

| Case | Before | After | Expected oracle |
|---|---|---|---|
| Fresh dependency solve | hts-sys 2.2.1 selected | hts-sys 2.2.0 selected | One workspace-wide compatible hts-sys instance |
| `cargo check -p mod_kit` | Exit 101; ten rust-htslib binding errors | Exit 0 | Existing rust-htslib 0.46.0 compiles |
| Workspace test suite | Cannot start after failed fresh build | 179 active tests pass; 14 declared ignored | No test failures |

## Testing

**Test environment**

- Revision tested: `18ebf054bed61de2ec7553d41fa81a8cc6938226`
- Tree tested and worktree state: `7e1b269f9804ff5e99db0420574462a8f8a6a065`; clean
- Parent revision: `5cecc3fb3a9336068d9e3c68d5c08d678153dd2c`
- Toolchain: rustc 1.90.0; cargo 1.90.0
- Platform: macOS 26.6, arm64
- Dependency resolution identity: parent generated lock SHA-256 `4af98bb22a10b9b65b86e00a4d5831b254fc6aec89fd51931c5aefd2861d0f9a`; fixed generated lock SHA-256 `d370908c0be24430282110489c8002550edd83a1811cf1bdc1dc68f972c01fc8`; neither ignored lockfile is in the diff

| Test layer | Exact command, fixture, or matrix | Result and evidence |
|---|---|---|
| **Core: parent-red regression** | Fresh detached parent; `cargo generate-lockfile --offline`; `cargo tree --offline --locked -i hts-sys`; `env CARGO_TARGET_DIR=/private/tmp/modkit-u01-parent-public-target cargo check --offline --locked -p mod_kit` | Resolves hts-sys 2.2.1; exits 101 with exactly ten rust-htslib E0308/E0609 errors |
| **Core: fixed dependency identity** | `cargo generate-lockfile --offline`; `cargo tree --offline --locked -i hts-sys` | One hts-sys 2.2.0 instance shared by mod_kit, modkit, ochm, safe-record, and rust-htslib |
| **Core: affected package/workspace check** | `cargo check --offline --locked --workspace --all-targets --quiet` | Exit 0; only pre-existing warnings |
| **Core: applicable full workspace gate** | Fresh-target `cargo test --workspace --all-targets -- --test-threads=1` on the frozen exact head | 179 passed, 14 declared ignored, 0 failed |
| Manifest/feature validation | `cargo metadata --offline --locked --format-version 1 --no-deps`; `cargo tree --offline --locked -e features -i hts-sys` | Manifest valid; one hts-sys version; existing bzip2/lzma/curl features retained |
| **Core: diff hygiene** | `git diff --check upstream/master...HEAD`; exact ancestry, diff, and clean-worktree checks | Passed; one commit, one changed manifest, two inserted lines, clean worktree |

### Tests not performed

- Real sequencing-data regression and output-byte comparisons were not run because the patch changes only dependency resolution and the complete workspace test suite exercises the compiled code.
- Performance, RSS, and I/O benchmarks were not run because the resolved runtime library version is the previously compatible 2.2.0 and no production code changes.
- `cargo clippy` was not run.
- `cargo fmt --all -- --check` was run but is not a passing gate: stable rustfmt reports pre-existing formatting differences in unchanged files (`modkit/tests/test_bedmethyl_util.rs`, `modkit-core/src/adjust.rs`, and `modkit-core/src/entropy/mod.rs`) plus the repository's nightly-only setting warnings. This PR changes only TOML; `git diff --check` passes.

## Scientific validation

- Population/eligibility invariant: no read, call, position, or sample-selection logic changes.
- Count/category conservation invariant: no scientific computation or serializer changes.
- Coordinate/strand/interval invariant: not affected.
- Determinism invariant: the fixed source revision now constrains the previously time-dependent hts-sys choice to one exact compatible version.
- Independent oracle: the same parent source fails only with 2.2.1 and succeeds when resolution is constrained to 2.2.0; exact dependency trees and full tests confirm the boundary.

## Output and compatibility

- User-visible change: fresh source builds succeed instead of failing in rust-htslib.
- Expected output differences: none.
- Byte-identical controls: not separately run; no Rust code or output path changes, and the full workspace suite passes.
- CLI/API/schema compatibility: unchanged.
- Partial-output or failure semantics: unchanged; this is a compile-time resolution fix.

## Reviewer guide

1. Review the two-line `modkit-core/Cargo.toml` diff and explanatory comment.
2. Reproduce the parent solve with `cargo generate-lockfile` and `cargo tree -i hts-sys`.
3. Confirm the fixed solve contains exactly one hts-sys 2.2.0 instance.
4. Rerun `cargo check --locked --workspace --all-targets` using the fixed generated lockfile.
5. Decide separately, outside this PR, whether modkit should later commit `Cargo.lock` and enforce `--locked` workflows.

## Checklist

- [x] The issue contains reproducible observed and expected behavior.
- [x] The change is limited to the linked issue’s approved scope.
- [x] The regression is demonstrably red on the exact parent revision.
- [x] All tests actually performed are listed above with their results.
- [x] Unrun or inapplicable tests are disclosed.
- [x] Scientific counts/statistics and output compatibility are explicitly checked.
- [x] Formatting and diff-hygiene results, including unrelated pre-existing findings, are documented.
- [x] No generated data, private sample identifiers, or unrelated changes are included.

