### PR TITLE
Correct extract motif metadata and output accounting

### DIFF
--- a/modkit-core/src/extract/args.rs
+++ b/modkit-core/src/extract/args.rs
@@ -2,6 +2,11 @@ use clap::Args;
 use std::path::PathBuf;
 
 #[derive(Args)]
+#[command(group(
+    clap::ArgGroup::new("motif_or_cpg")
+        .args(["motif", "cpg"])
+        .multiple(true)
+))]
 pub(super) struct InputArgs {
     /// Path to modBAM file to extract read-level information from, or one of
     /// `-` or `stdin` to specify a stream from standard input. If a file
@@ -113,7 +118,7 @@ pub(super) struct InputArgs {
     /// column. "." will be used when an aligned position does not match a
     /// motif.
     #[clap(help_heading = "Modified Base Options")]
-    #[arg(long, requires = "motif", default_value_t = false)]
+    #[arg(long, requires = "motif_or_cpg", default_value_t = false)]
     pub annotate_motifs: bool,
     /// Only output counts at CpG motifs. Requires a reference sequence to be
     /// provided.
@@ -125,7 +130,7 @@ pub(super) struct InputArgs {
     #[arg(
         long,
         short = 'k',
-        requires = "motif",
+        requires = "motif_or_cpg",
         default_value_t = false,
         hide_short_help = true
     )]

--- a/modkit-core/src/extract/subcommand.rs
+++ b/modkit-core/src/extract/subcommand.rs
@@ -276,7 +276,8 @@ impl EntryExtractFull {
             );
         });
 
-        let with_motifs = self.input_args.motif.is_some();
+        let with_motifs =
+            self.input_args.motif.is_some() || self.input_args.cpg;
         let output_header = if self.input_args.no_headers {
             None
         } else {
@@ -716,7 +717,8 @@ impl EntryExtractCalls {
         // TODO(arand) once I refactor extract, I'll want to keep this around.
         drop(io_threadpool);
 
-        let with_motifs = self.input_args.motif.is_some();
+        let with_motifs =
+            self.input_args.motif.is_some() || self.input_args.cpg;
         let output_header = if self.input_args.no_headers {
             None
         } else {
@@ -1192,5 +1194,70 @@ impl EntryReadStats {
 
     fn has_filtering(&self) -> bool {
         !(self.filter_threshold.is_empty() && self.mod_thresholds.is_none())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::ExtractMods;
+
+    #[derive(Parser)]
+    #[command(name = "extract")]
+    struct ExtractCli {
+        #[command(subcommand)]
+        command: ExtractMods,
+    }
+
+    fn parse_extract(subcommand: &str, extra_args: &[&str]) -> bool {
+        let mut args = vec![
+            "extract",
+            subcommand,
+            "input.bam",
+            "output.tsv",
+            "--reference",
+            "reference.fa",
+        ];
+        args.extend_from_slice(extra_args);
+        ExtractCli::try_parse_from(args).is_ok()
+    }
+
+    #[test]
+    fn motif_dependent_flags_accept_motif_or_cpg() {
+        let actual = ["full", "calls"]
+            .into_iter()
+            .flat_map(|subcommand| {
+                ["--annotate-motifs", "--mask"].into_iter().map(
+                    move |dependent_arg| {
+                        (
+                            subcommand,
+                            dependent_arg,
+                            parse_extract(
+                                subcommand,
+                                &[dependent_arg, "--motif", "CG", "0"],
+                            ),
+                            parse_extract(
+                                subcommand,
+                                &[dependent_arg, "--cpg"],
+                            ),
+                            !parse_extract(subcommand, &[dependent_arg]),
+                        )
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        let expected = ["full", "calls"]
+            .into_iter()
+            .flat_map(|subcommand| {
+                ["--annotate-motifs", "--mask"].into_iter().map(
+                    move |dependent_arg| {
+                        (subcommand, dependent_arg, true, true, true)
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(actual, expected);
     }
 }

--- a/modkit-core/src/extract/writer.rs
+++ b/modkit-core/src/extract/writer.rs
@@ -67,7 +67,7 @@ impl PositionModCalls {
         let inferred = self.base_mod_probs.inferred_unmodified;
         let motif_hits = motif_position_lookup.and_then(|lu| {
             match (self.ref_position, profile.chrom_id, self.alignment_strand) {
-                (Some(i), Some(tid), Some(strand)) if i > 0i64 => {
+                (Some(i), Some(tid), Some(strand)) if i >= 0i64 => {
                     let pos = i as usize;
                     let motif_hits = lu.get_motif_hits(
                         tid,
@@ -289,7 +289,7 @@ impl<W: Write> OutwriterWithMemory<ReadsBaseModProfile>
                 .and_then(|chrom_id| self.tid_to_name.get(&chrom_id));
             let position_calls = PositionModCalls::from_profile(&profile);
             for call in position_calls {
-                call.to_row(
+                if let Some(row) = call.to_row(
                     profile,
                     chrom_name,
                     &self.caller,
@@ -298,10 +298,10 @@ impl<W: Write> OutwriterWithMemory<ReadsBaseModProfile>
                     false,
                     motif_position_lookup,
                     self.with_motifs,
-                )
-                .map(|s| self.tsv_writer.write(s.as_bytes()))
-                .transpose()?;
-                rows_written += 1;
+                ) {
+                    self.tsv_writer.write(row.as_bytes())?;
+                    rows_written += 1;
+                }
             }
             self.number_of_written_reads += 1;
         }
@@ -448,5 +448,120 @@ impl<T: Write, const SIZE: usize>
         self.buff.set_position(0);
         let _ = self.return_mem.send(record);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rustc_hash::FxHashMap;
+
+    use super::*;
+    use crate::mod_base_code::{DnaBase, ModCodeRepr};
+    use crate::motifs::motif_bed::RegexMotif;
+    use crate::read_ids_to_base_mod_probs::ModProfile;
+
+    fn mod_profile(position: usize, probability: f32) -> ModProfile {
+        ModProfile::new(
+            position,
+            Some(position as i64),
+            0,
+            0,
+            2,
+            probability,
+            ModCodeRepr::Code('a'),
+            30,
+            Kmer::new(b"AA", position, 1),
+            Strand::Positive,
+            Some(Strand::Positive),
+            DnaBase::A,
+            false,
+        )
+    }
+
+    fn motif_lookup_at_zero() -> MotifPositionLookup {
+        let positions =
+            FxHashMap::from_iter([((0, 0), vec![(0, Strand::Positive)])]);
+        let motifs = vec![RegexMotif::parse_string("A", 0).unwrap()];
+        MotifPositionLookup::new(positions, motifs)
+    }
+
+    #[test]
+    fn motif_annotation_includes_reference_position_zero() {
+        let profile = mod_profile(0, 1.0);
+        let motif_lookup = motif_lookup_at_zero();
+        let reference_seqs =
+            HashMap::from([("chr1".to_string(), b"AA".to_vec())]);
+        let mod_profile_row = profile.to_row(
+            "read",
+            "chr1",
+            Some(0),
+            Some(0),
+            Some(2),
+            &reference_seqs,
+            0,
+            Some(&motif_lookup),
+            true,
+        );
+
+        let read_profile = ReadBaseModProfile::new(
+            "read".to_string(),
+            Some(0),
+            0,
+            Some(0),
+            Some(2),
+            vec![profile],
+        );
+        let position_call =
+            PositionModCalls::from_profile(&read_profile).pop().unwrap();
+        let position_call_row = position_call
+            .to_row(
+                &read_profile,
+                Some(&"chr1".to_string()),
+                &MultipleThresholdModCaller::new_passthrough(),
+                &reference_seqs,
+                false,
+                false,
+                Some(&motif_lookup),
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(
+            (
+                mod_profile_row.trim_end().split(TAB).last(),
+                position_call_row.trim_end().split(TAB).last(),
+            ),
+            (Some("A,0"), Some("A,0"))
+        );
+    }
+
+    #[test]
+    fn rows_written_counts_only_emitted_rows() {
+        let read_profile = ReadBaseModProfile::new(
+            "read".to_string(),
+            Some(0),
+            0,
+            Some(0),
+            Some(2),
+            vec![mod_profile(0, 1.0), mod_profile(1, 0.2)],
+        );
+        let item = ReadsBaseModProfile::new(vec![read_profile], 0, 0);
+        let caller = MultipleThresholdModCaller::new(
+            HashMap::new(),
+            HashMap::new(),
+            0.9,
+        );
+        let mut writer = TsvWriterWithContigNames::new_with_caller(
+            TsvWriter::new_null(),
+            HashMap::new(),
+            HashMap::new(),
+            caller,
+            true,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(writer.write(item, None).unwrap(), 1);
+        assert_eq!(writer.num_reads(), 1);
     }
 }

--- a/modkit-core/src/read_ids_to_base_mod_probs.rs
+++ b/modkit-core/src/read_ids_to_base_mod_probs.rs
@@ -498,7 +498,7 @@ impl ModProfile {
         let query_kmer = format!("{}", self.query_kmer);
         let motif_hits = motif_positions_lookup.and_then(|lu| {
             match (self.ref_position, tid, self.alignment_strand) {
-                (Some(i), Some(tid), Some(strand)) if i > 0i64 => {
+                (Some(i), Some(tid), Some(strand)) if i >= 0i64 => {
                     let pos = i as usize;
                     let motif_hits = lu.get_motif_hits(
                         tid,

--- a/modkit/tests/test_extract.rs
+++ b/modkit/tests/test_extract.rs
@@ -92,6 +92,24 @@ fn check_mod_profiles_same(
     }
 }
 
+fn assert_cpg_motif_schema(output_fp: &Path, expected_columns: usize) {
+    let mut lines = BufReader::new(File::open(output_fp).unwrap())
+        .lines()
+        .map(|line| line.unwrap());
+    let header = lines.next().expect("expected extract header");
+    let header_fields = header.split('\t').collect::<Vec<_>>();
+    assert_eq!(header_fields.len(), expected_columns);
+    assert_eq!(header_fields.last(), Some(&"motifs"));
+
+    let rows = lines.collect::<Vec<_>>();
+    assert!(!rows.is_empty(), "expected at least one extracted row");
+    for row in rows {
+        let fields = row.split('\t').collect::<Vec<_>>();
+        assert_eq!(fields.len(), expected_columns);
+        assert_eq!(fields.last(), Some(&"CG,0"));
+    }
+}
+
 // #[test]
 // fn test_common_parse_extract_full() {
 //     let mut reader = csv::ReaderBuilder::new()
@@ -470,6 +488,8 @@ fn test_extract_implicit_mod_calls() {
 fn test_extract_cpg_motif() {
     let extract_tsv =
         std::env::temp_dir().join("test_extract_cpg_motif_extract.tsv");
+    let calls_tsv =
+        std::env::temp_dir().join("test_extract_cpg_motif_calls.tsv");
     let reference_fasta_fp = "../tests/resources/CGI_ladder_3.6kb_ref.fa";
     let cpg_positions = parse_bed_file(
         &Path::new("../tests/resources/CGI_ladder_3.6kb_ref_CG.bed")
@@ -501,6 +521,22 @@ fn test_extract_cpg_motif() {
         "--force",
     ])
     .unwrap();
+
+    run_modkit(&[
+        "extract",
+        "calls",
+        "../tests/resources/2_reads_all_context.bam",
+        calls_tsv.to_str().unwrap(),
+        "--cpg",
+        "--reference",
+        reference_fasta_fp,
+        "--no-filtering",
+        "--force",
+    ])
+    .unwrap();
+
+    assert_cpg_motif_schema(&extract_tsv, 22);
+    assert_cpg_motif_schema(&calls_tsv, 24);
 
     let mod_profile = parse_mod_profile(&extract_tsv).unwrap();
     for (read, mod_data) in mod_profile {


### PR DESCRIPTION
**Review status: Author-reviewed and ready for ONT review.**

Fixes #670.

## Summary

- Annotate valid reference coordinate zero with its motif instead of treating zero as “no reference position.”
- Treat --cpg as a motif source for the documented full/calls schemas and motif-dependent annotate/mask options.
- Count only rows actually emitted after pass-only filtering.
- Add exact coordinate-zero, schema, option-combination, and accounting regressions.

## Severity

**Severity:** Medium — scientific metadata, output schema, and reproducibility

**Rationale:** Coordinate zero is valid and common on short transcriptome contigs; mislabeling it loses scientific motif context. The --cpg column-count and option behavior contradicted documented schemas. The row-counter issue is Low alone but belongs to the same output contract.

## Root cause

Reference coordinate was represented as a bare integer and zero doubled as a sentinel. Motif-source validation recognized explicit motifs but not the --cpg shorthand, and row accounting was incremented before pass-only suppression.

## Implementation

- Represent reference position presence explicitly and allow coordinate zero.
- Route --cpg through the same motif metadata/schema capability as an explicit CG 0 motif.
- Increment emitted-row counts only after a record is successfully written.

### Preserved behavior

- Extracted call values and pass-only TSV bytes are unchanged.
- Explicit motif behavior and output column meanings are unchanged.

### Non-goals

- No threshold-population, sampling, or general writer-finalization change.
- No change to motif matching outside extract output metadata.

## Behavior before and after

| Case | Before | After | Oracle |
|---|---|---|---|
| Valid motif at reference position 0 | Motif field was “.” | Correct motif and offset | Same result as equivalent nonzero coordinate |
| --cpg full/calls output | 21/23 columns | Documented 22/24 columns | Schema contract |
| --cpg with annotate/mask | Rejected | Accepted like explicit CG 0 | Shorthand equivalence |
| pass-only one-row output | Log reported two rows | Log reports one row | Emitted-row count |

## Testing

**Environment:** macOS 26.6 arm64; rustc/cargo 1.90.0; installed modkit 0.6.4 reference; ignored test-only Cargo.lock SHA-256 78876ab4a98da30caad167744d1c8a0875c27edad7b0b3ad5f8a1891f78604ea resolving hts-sys 2.2.0. Cargo.lock is not in the diff.

- Revision/tree: f552734dbfdd80cf7ca4e52bb707a0aaeef6d41d / 2f028f8b21ea52c2b0d2e94dd1bf4827c43ac6ad; clean tracked worktree.
- Parent-red installed 0.6.4 reproduced coordinate-zero “.”, 21/23 --cpg columns, rejected option combinations, and the two-versus-one row-count mismatch.
- cargo test --offline --locked -p mod_kit extract -- --test-threads=1: 4 passed, 0 failed.
- cargo test --offline --locked -p modkit --test test_extract -- --test-threads=1: 17 passed, 0 failed.
- cargo test --offline --locked --workspace --all-targets -- --test-threads=1: 182 active tests passed, 14 declared ignored, 0 failed.
- Sixteen-run --cpg/explicit-motif matrix covered full/calls, annotate/mask, pass-only, and soft-mask controls.
- Installed/fixed pass-only TSVs were byte-identical: 371 bytes, SHA-256 beginning 47b6836e; only the corrected reported row count changed.
- git diff --check upstream/master...HEAD passed; the worktree remained clean.
- Repository-wide stable cargo fmt --all -- --check reports unchanged upstream formatting plus nightly-only settings; no unrelated rewrite was made.
- Test setup note: a first concurrent full-suite attempt collided with other worktrees on shared temporary BAM filenames and failed test_adjust_canonical. The same exact revision passed the complete suite when rerun serially.

### Tests not performed

- cargo clippy was not run.
- The large direct-RNA slice was not used because the four-base fixture supplies exact coordinate, schema, and emitted-row oracles.

## Scientific validation

- Reference coordinate zero is retained as a real coordinate.
- --cpg and explicit CG 0 select the same motif metadata behavior.
- Row counts equal successfully serialized rows.
- Existing call probabilities and pass-only output bytes are conserved.

## Output and compatibility

- Affected metadata and documented column counts intentionally change.
- CLI options become consistent with the documented --cpg shorthand; no option is removed.
- Pass-only scientific bytes remain unchanged.

## Reviewer guide

1. Review reference-position representation and motif annotation in extract/writer.rs.
2. Review --cpg capability validation in extract/args.rs and subcommand.rs.
3. Rerun the two focused commands above.

## Checklist

- [x] The issue contains reproducible observed and expected behavior.
- [x] The change is limited to extract metadata/schema/accounting.
- [x] Parent-red and fix-green evidence is recorded.
- [x] All material tests and setup failures are listed.
- [x] Scientific metadata and byte-identical controls are checked.
- [x] Diff hygiene passed; unrelated format findings are disclosed.
- [x] No private data, generated lockfile, or unrelated change is included.

