### PR TITLE
Correct pileup motif ownership, validation, and mask limits

### DIFF
--- a/book/src/advanced_usage.md
+++ b/book/src/advanced_usage.md
@@ -269,10 +269,12 @@ Modified Base Options:
           is used, the resulting output BED file will indicate the motif in the
           "name" field as <mod_code>,<motif>,<offset>. For example, given
           `--motif CGCG 2 --motif CG 0` there will be output lines with name
-          fields such as "m,CG,0" and "m,CGCG,2". To use `--combine-strands`,
-          exactly one motif must be supplied. It must be reverse-complement
-          palindromic, and the reverse-strand anchor must not precede the
-          forward-strand anchor, or an error will be raised.
+          fields such as "m,CG,0" and "m,CGCG,2". At most eight motifs are
+          supported, including motifs added by `--cpg` or `--modified-bases`.
+          To use `--combine-strands`, exactly one motif must be supplied. It
+          must be reverse-complement palindromic, and the reverse-strand anchor
+          must not precede the forward-strand anchor, or an error will be
+          raised.
 
       --cpg
           Only output counts at CpG motifs

--- a/book/src/advanced_usage.md
+++ b/book/src/advanced_usage.md
@@ -269,9 +269,10 @@ Modified Base Options:
           is used, the resulting output BED file will indicate the motif in the
           "name" field as <mod_code>,<motif>,<offset>. For example, given
           `--motif CGCG 2 --motif CG 0` there will be output lines with name
-          fields such as "m,CG,0" and "m,CGCG,2". To use this option with
-          `--combine-strands`, all motifs must be reverse-complement palindromic
-          or an error will be raised.
+          fields such as "m,CG,0" and "m,CGCG,2". To use `--combine-strands`,
+          exactly one motif must be supplied. It must be reverse-complement
+          palindromic, and the reverse-strand anchor must not precede the
+          forward-strand anchor, or an error will be raised.
 
       --cpg
           Only output counts at CpG motifs

--- a/book/src/intro_pileup.md
+++ b/book/src/intro_pileup.md
@@ -141,6 +141,8 @@ oligo_741_adapters  39 40 m,CG,0   4	-	39	40	255,0,0	4 100.00 4 0 0 0 0 0 0
 oligo_741_adapters  39 40 m,CGCG,2 4	-	39	40	255,0,0	4 100.00 4 0 0 0 0 0 0
 ```
 
+Pileup supports at most eight motifs, including motifs added by `--cpg` or `--modified-bases`.
+
 The `--combine-strands` flag requires exactly one motif, supplied with `--motif` or `--cpg`, and that motif must be reverse-complement palindromic (`CG` _is_ a palindrome but `CHH` is not).
 The reverse-strand anchor must not precede the forward-strand anchor; for example, `--motif CGCG 0 --combine-strands` is supported, while `--motif CGCG 2 --combine-strands` is not currently supported.
 See [limitations](./limitations.md) for more details.

--- a/book/src/intro_pileup.md
+++ b/book/src/intro_pileup.md
@@ -141,8 +141,9 @@ oligo_741_adapters  39 40 m,CG,0   4	-	39	40	255,0,0	4 100.00 4 0 0 0 0 0 0
 oligo_741_adapters  39 40 m,CGCG,2 4	-	39	40	255,0,0	4 100.00 4 0 0 0 0 0 0
 ```
 
-The `--combine-strands` flag can be combined with `--motif` however all motifs must be reverse-complement palindromic (`CG` _is_ a palindrome but `CHH` is not).
-Only one motif at a time is supported with `--combine-strands` is used (see [limitations](./limitations.md) for details).
+The `--combine-strands` flag requires exactly one motif, supplied with `--motif` or `--cpg`, and that motif must be reverse-complement palindromic (`CG` _is_ a palindrome but `CHH` is not).
+The reverse-strand anchor must not precede the forward-strand anchor; for example, `--motif CGCG 0 --combine-strands` is supported, while `--motif CGCG 2 --combine-strands` is not currently supported.
+See [limitations](./limitations.md) for more details.
 
 ## Partitioning reads based on phasing information with `--phased`
 

--- a/modkit-core/src/fasta.rs
+++ b/modkit-core/src/fasta.rs
@@ -21,6 +21,10 @@ struct HtsFastaHandle {
     contigs: FxHashMap<String, u64>,
     preloaded: bool,
     sequences: FxHashMap<String, String>,
+    #[cfg(test)]
+    sequence_fetches: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    #[cfg(test)]
+    sequence_bases_fetched: std::sync::Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl HtsFastaHandle {
@@ -65,6 +69,10 @@ impl HtsFastaHandle {
             contigs,
             sequences,
             preloaded: preload,
+            #[cfg(test)]
+            sequence_fetches: Default::default(),
+            #[cfg(test)]
+            sequence_bases_fetched: Default::default(),
         })
     }
 
@@ -80,6 +88,15 @@ impl HtsFastaHandle {
             } else if start == end {
                 Ok(String::new())
             } else {
+                #[cfg(test)]
+                {
+                    self.sequence_fetches
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    self.sequence_bases_fetched.fetch_add(
+                        end - start,
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                }
                 let seq = if self.preloaded
                     && self.sequences.get(contig).is_some()
                 {
@@ -105,6 +122,15 @@ impl HtsFastaHandle {
 
     fn has_sequence(&self, seq_name: &str) -> bool {
         self.contigs.contains_key(seq_name)
+    }
+
+    #[cfg(test)]
+    fn sequence_fetch_stats(&self) -> (usize, u64) {
+        (
+            self.sequence_fetches.load(std::sync::atomic::Ordering::Relaxed),
+            self.sequence_bases_fetched
+                .load(std::sync::atomic::Ordering::Relaxed),
+        )
     }
 }
 
@@ -771,6 +797,67 @@ mod fasta_mod_tests {
                     (3, Strand::Negative, 0),
                     (5, Strand::Negative, 0),
                 ]
+            );
+        }
+    }
+
+    #[test]
+    fn combined_strand_dense_overlap_scan_work_is_bounded() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let repeat_count = 256usize;
+        let sequence = format!("{}NN", "CG".repeat(repeat_count));
+        let fasta_path = write_fasta(temp_dir.path(), &sequence);
+        let motif = RegexMotif::parse_string("CGCG", 0).unwrap();
+        let mut expected = (0..repeat_count - 1)
+            .flat_map(|i| {
+                [
+                    (2 * i as u64, Strand::Positive, 0),
+                    (2 * i as u64 + 3, Strand::Negative, 0),
+                ]
+            })
+            .collect::<Vec<_>>();
+        expected.sort_by_key(|(position, strand, motif_idx)| {
+            (*position, *strand, *motif_idx)
+        });
+
+        for preload in [false, true] {
+            let mut lookup = MotifLocationsLookup::from_paths(
+                &fasta_path,
+                false,
+                None,
+                vec![motif.clone()],
+                preload,
+            )
+            .unwrap();
+            let (focus_positions, actual_end) = lookup
+                .get_motif_positions(
+                    "chr1",
+                    0,
+                    sequence.len() as u32,
+                    0..1,
+                    None,
+                    true,
+                )
+                .unwrap();
+
+            assert_eq!(actual_end, (repeat_count * 2) as u32);
+            assert_eq!(
+                decode_motif_mask(focus_positions, 0..actual_end as u64, 1,),
+                expected,
+                "preload={preload}"
+            );
+
+            let (fetches, bases_fetched) = lookup.reader.sequence_fetch_stats();
+            assert!(
+                fetches <= 12,
+                "dense overlap required {fetches} sequence fetches with \
+                 preload={preload}"
+            );
+            assert!(
+                bases_fetched <= 3 * sequence.len() as u64,
+                "dense overlap fetched {bases_fetched} bases for a {}-base \
+                 reference with preload={preload}",
+                sequence.len()
             );
         }
     }

--- a/modkit-core/src/fasta.rs
+++ b/modkit-core/src/fasta.rs
@@ -5,7 +5,6 @@ use bitvec::bitvec;
 use bitvec::vec::BitVec;
 use itertools::Itertools;
 use log::debug;
-use rayon::prelude::*;
 use rust_htslib::faidx;
 use rustc_hash::FxHashMap;
 use substring::Substring;
@@ -76,8 +75,10 @@ impl HtsFastaHandle {
         end: u64,
     ) -> MkResult<String> {
         if let Some(length) = self.contigs.get(contig) {
-            if end > *length {
+            if start > end || end > *length {
                 Err(MkError::InvalidReferenceCoordinates)
+            } else if start == end {
+                Ok(String::new())
             } else {
                 let seq = if self.preloaded
                     && self.sequences.get(contig).is_some()
@@ -88,7 +89,11 @@ impl HtsFastaHandle {
                     let tmp_reader = faidx::Reader::from_path(&self.fasta_fp)
                         .map_err(|e| MkError::HtsLibError(e))?;
                     tmp_reader
-                        .fetch_seq_string(contig, start as usize, end as usize)
+                        .fetch_seq_string(
+                            contig,
+                            start as usize,
+                            end.saturating_sub(1) as usize,
+                        )
                         .map_err(|e| MkError::HtsLibError(e))?
                 };
                 Ok(seq)
@@ -175,104 +180,212 @@ impl MotifLocationsLookup {
     }
 
     #[inline]
-    fn get_motifs_on_seq(
+    fn get_motifs_for_owner(
         &self,
-        seq: &str,
-        start: u64,
+        contig: &str,
+        owner: std::ops::Range<u64>,
         tid: u32,
         stranded_position_filter: Option<&StrandedPositionFilter<()>>,
-    ) -> BitVec {
+    ) -> MkResult<BitVec> {
         debug_assert!(!self.motifs.is_empty());
         let num_motifs = self.motifs.len();
         assert!(num_motifs < u8::MAX as usize);
         let bits_per_pos = self.motifs.len() * 2; // two strands
-        let mut mask = bitvec![0; seq.len() * bits_per_pos];
+        let ref_end = *self.reader.contigs.get(contig).ok_or_else(|| {
+            MkError::ContigMissing(format!("{contig} not in FASTA index"))
+        })?;
+        if owner.start > owner.end || owner.end > ref_end {
+            return Err(MkError::InvalidReferenceCoordinates);
+        }
+        let owner_len = (owner.end - owner.start) as usize;
+        let mut mask = bitvec![0; owner_len * bits_per_pos];
+        if owner.is_empty() {
+            return Ok(mask);
+        }
+
+        // Motif anchors belong to exactly one half-open owner interval, but
+        // discovering an anchor may require bases on either side of it. Fetch
+        // enough clipped context for the longest motif, then translate every
+        // local hit back to its global reference coordinate before filtering
+        // and writing it into the owner-local mask.
+        let context = self.longest_motif_length.saturating_sub(1);
+        let fetch_start = owner.start.saturating_sub(context);
+        let fetch_end = owner.end.saturating_add(context).min(ref_end);
+        let seq = self.reader.get_sequence(contig, fetch_start, fetch_end)?;
+        let seq = if self.mask { seq } else { seq.to_ascii_uppercase() };
 
         for (offset, motif) in self.motifs.iter().enumerate() {
-            let positions = if let Some(spf) = stranded_position_filter {
-                find_motif_hits(seq, motif)
-                    .into_par_iter()
-                    .filter(|(pos, strand)| {
-                        spf.contains(
-                            tid as i32,
-                            (*pos as u64).saturating_add(start),
-                            *strand,
-                        )
+            for (local_pos, strand) in find_motif_hits(&seq, motif) {
+                let global_pos = fetch_start.saturating_add(local_pos as u64);
+                if !owner.contains(&global_pos)
+                    || stranded_position_filter.is_some_and(|spf| {
+                        !spf.contains(tid as i32, global_pos, strand)
                     })
-                    .collect::<Vec<(usize, Strand)>>()
-            } else {
-                find_motif_hits(seq, motif)
-            };
-            for (pos, strand) in positions {
+                {
+                    continue;
+                }
+                let owner_pos = (global_pos - owner.start) as usize;
                 match strand {
                     Strand::Positive => {
-                        mask.set((pos * bits_per_pos) + offset, true)
+                        mask.set((owner_pos * bits_per_pos) + offset, true)
                     }
                     Strand::Negative => mask.set(
-                        ((pos * bits_per_pos) + num_motifs) + offset,
+                        ((owner_pos * bits_per_pos) + num_motifs) + offset,
                         true,
                     ),
                 }
             }
         }
-        mask
+        Ok(mask)
+    }
+
+    /// Find complete palindromic-motif anchor pairs owned by their positive
+    /// anchor. A combined-strand output row is written at that positive
+    /// coordinate, so the region and any stranded position filter must select
+    /// that coordinate; the paired negative anchor is then admitted
+    /// atomically even when a strand-specific filter does not select it.
+    fn get_combined_motif_pairs(
+        &self,
+        contig: &str,
+        positive_owner: std::ops::Range<u64>,
+        owner_limit: u64,
+        tid: u32,
+        stranded_position_filter: Option<&StrandedPositionFilter<()>>,
+    ) -> MkResult<Vec<(u64, u64, usize)>> {
+        let ref_end = *self.reader.contigs.get(contig).ok_or_else(|| {
+            MkError::ContigMissing(format!("{contig} not in FASTA index"))
+        })?;
+        if positive_owner.start > positive_owner.end
+            || positive_owner.end > owner_limit
+            || owner_limit > ref_end
+        {
+            return Err(MkError::InvalidReferenceCoordinates);
+        }
+        if positive_owner.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let context = self.longest_motif_length.saturating_sub(1);
+        let fetch_start = positive_owner.start.saturating_sub(context);
+        let fetch_end = positive_owner.end.saturating_add(context).min(ref_end);
+        let seq = self.reader.get_sequence(contig, fetch_start, fetch_end)?;
+        let seq = if self.mask { seq } else { seq.to_ascii_uppercase() };
+
+        let mut pairs = Vec::new();
+        for (motif_idx, motif) in self.motifs.iter().enumerate() {
+            debug_assert!(motif.is_palendrome());
+            let forward_offset = motif.forward_offset() as u64;
+            let reverse_offset = motif.reverse_offset() as u64;
+            for (local_pos, strand) in find_motif_hits(&seq, motif) {
+                if strand != Strand::Positive {
+                    continue;
+                }
+                let Some(positive_position) =
+                    fetch_start.checked_add(local_pos as u64)
+                else {
+                    continue;
+                };
+                if !positive_owner.contains(&positive_position)
+                    || stranded_position_filter.is_some_and(|spf| {
+                        !spf.contains(
+                            tid as i32,
+                            positive_position,
+                            Strand::Positive,
+                        )
+                    })
+                {
+                    continue;
+                }
+                let negative_position = if reverse_offset >= forward_offset {
+                    positive_position
+                        .checked_add(reverse_offset - forward_offset)
+                } else {
+                    positive_position
+                        .checked_sub(forward_offset - reverse_offset)
+                };
+                let Some(negative_position) = negative_position else {
+                    continue;
+                };
+
+                // Both anchors must be in the same selected reference region
+                // and owner. In particular, never expose a reverse anchor
+                // whose positive owner is before the region start.
+                if negative_position < positive_owner.start
+                    || negative_position >= owner_limit
+                {
+                    continue;
+                }
+                pairs.push((positive_position, negative_position, motif_idx));
+            }
+        }
+        Ok(pairs)
     }
 
     fn get_motif_positions_combine_strands(
         &mut self,
         contig: &str,
         tid: u32,
-        _ref_end: u64,
+        ref_end: u64,
         range: std::ops::Range<u64>,
         stranded_position_filter: Option<&StrandedPositionFilter<()>>,
     ) -> MkResult<(FocusPositions2, u32)> {
-        let ref_end = *self.reader.contigs.get(contig).ok_or_else(|| {
+        let contig_end = *self.reader.contigs.get(contig).ok_or_else(|| {
             MkError::ContigMissing(format!("{contig} not in FASTA index"))
         })?;
-        let buffer_size = self.longest_motif_length * 5;
+        let owner_limit = ref_end.min(contig_end);
+        if range.start > range.end || range.end > owner_limit {
+            return Err(MkError::InvalidReferenceCoordinates);
+        }
         let num_motifs = self.motifs.len();
-        let bits_per_pos = (num_motifs * 2) as u64; // two strands
+        let bits_per_pos = num_motifs * 2; // two strands
+        if range.is_empty() {
+            let mask = bitvec![0; 0];
+            return Ok((
+                FocusPositions2::MotifMask {
+                    mask,
+                    num_motifs: self.num_motifs() as u8,
+                },
+                range.end as u32,
+            ));
+        }
+
         let mut end = range.end;
-        let mut end_w_buffer = std::cmp::min(range.end + buffer_size, ref_end);
-        let mask = 'fetch_loop: loop {
-            let seq =
-                self.reader.get_sequence(contig, range.start, end_w_buffer)?;
-            let seq = if self.mask { seq } else { seq.to_ascii_uppercase() };
-            let mask = self.get_motifs_on_seq(
-                &seq,
-                range.start,
+        let (mask, end) = loop {
+            let pairs = self.get_combined_motif_pairs(
+                contig,
+                range.start..end,
+                owner_limit,
                 tid,
                 stranded_position_filter,
-            );
-            let mut end_idx = ((end - range.start - 1) * bits_per_pos) as usize;
-            assert!(
-                (end_idx + num_motifs) < mask.len(),
-                "off the end {} {}",
-                end_idx + num_motifs,
-                mask.len()
-            );
-
-            while mask[end_idx..(end_idx + num_motifs)].any() {
-                debug!("end_idx ({end_idx}) hits a motif.. end={end}",);
-                end = std::cmp::min(
-                    end.saturating_add(self.longest_motif_length),
-                    ref_end,
-                );
-                end_idx = ((end - range.start - 1) * bits_per_pos) as usize;
+            )?;
+            let required_end = pairs
+                .iter()
+                .filter_map(|(positive, negative, _)| {
+                    positive.max(negative).checked_add(1)
+                })
+                .max()
+                .unwrap_or(end);
+            if required_end > end {
                 debug!(
-                    "moved end_idx to {end_idx}, end={end} ref_end={ref_end}, \
-                     contig={contig}, range={range:?}"
+                    "extending combined motif owner from {end} to \
+                     {required_end}, contig={contig}, range={range:?}"
                 );
-                debug_assert!(end_idx + num_motifs < mask.len());
-                if end >= end_w_buffer {
-                    debug!("too close, re-fetching..");
-                    end_w_buffer =
-                        std::cmp::min(end.saturating_add(buffer_size), ref_end);
-                    continue 'fetch_loop;
-                }
-                debug!("re-check..");
+                end = required_end;
+                continue;
             }
-            break mask;
+
+            let mut mask =
+                bitvec![0; (end - range.start) as usize * bits_per_pos];
+            for (positive, negative, motif_idx) in pairs {
+                let positive_local = (positive - range.start) as usize;
+                let negative_local = (negative - range.start) as usize;
+                mask.set((positive_local * bits_per_pos) + motif_idx, true);
+                mask.set(
+                    (negative_local * bits_per_pos) + num_motifs + motif_idx,
+                    true,
+                );
+            }
+            break (mask, end);
         };
         Ok((
             FocusPositions2::MotifMask {
@@ -301,15 +414,12 @@ impl MotifLocationsLookup {
                 stranded_position_filter,
             )
         } else {
-            let seq =
-                self.reader.get_sequence(contig, range.start, range.end)?;
-            let seq = if self.mask { seq } else { seq.to_ascii_uppercase() };
-            let mask = self.get_motifs_on_seq(
-                &seq,
-                range.start,
+            let mask = self.get_motifs_for_owner(
+                contig,
+                range.clone(),
                 tid,
                 stranded_position_filter,
-            );
+            )?;
             let focus_positions = FocusPositions2::MotifMask {
                 mask,
                 num_motifs: self.num_motifs() as u8,
@@ -329,9 +439,415 @@ impl MotifLocationsLookup {
 
 #[cfg(test)]
 mod fasta_mod_tests {
-    use crate::fasta::HtsFastaHandle;
+    use std::{
+        fs::File,
+        io::Write,
+        ops::Range,
+        path::{Path, PathBuf},
+    };
+
     use rand::prelude::{SeedableRng, StdRng};
+    use rust_lapper::Lapper;
+    use rustc_hash::FxHashMap;
     use rv::prelude::Rv;
+
+    use crate::{
+        fasta::{HtsFastaHandle, MotifLocationsLookup},
+        interval_chunks::FocusPositions2,
+        motifs::motif_bed::RegexMotif,
+        position_filter::{Iv, StrandedPositionFilter},
+        util::Strand,
+    };
+
+    fn write_fasta(root: &Path, sequence: &str) -> PathBuf {
+        let fasta_path = root.join("reference.fa");
+        File::create(&fasta_path)
+            .unwrap()
+            .write_all(format!(">chr1\n{sequence}\n").as_bytes())
+            .unwrap();
+        File::create(root.join("reference.fa.fai"))
+            .unwrap()
+            .write_all(
+                format!(
+                    "chr1\t{}\t6\t{}\t{}\n",
+                    sequence.len(),
+                    sequence.len(),
+                    sequence.len() + 1
+                )
+                .as_bytes(),
+            )
+            .unwrap();
+        fasta_path
+    }
+
+    fn decode_motif_mask(
+        focus_positions: FocusPositions2,
+        range: Range<u64>,
+        num_motifs: usize,
+    ) -> Vec<(u64, Strand, usize)> {
+        let FocusPositions2::MotifMask { mask, num_motifs: observed } =
+            focus_positions
+        else {
+            panic!("expected motif mask")
+        };
+        assert_eq!(observed as usize, num_motifs);
+        let bits_per_pos = num_motifs * 2;
+        assert_eq!(
+            mask.len(),
+            (range.end - range.start) as usize * bits_per_pos,
+            "motif mask must cover exactly its owner interval"
+        );
+        let mut hits = Vec::new();
+        for local_pos in 0..(range.end - range.start) as usize {
+            for motif_idx in 0..num_motifs {
+                if mask[(local_pos * bits_per_pos) + motif_idx] {
+                    hits.push((
+                        range.start + local_pos as u64,
+                        Strand::Positive,
+                        motif_idx,
+                    ));
+                }
+                if mask[(local_pos * bits_per_pos) + num_motifs + motif_idx] {
+                    hits.push((
+                        range.start + local_pos as u64,
+                        Strand::Negative,
+                        motif_idx,
+                    ));
+                }
+            }
+        }
+        hits
+    }
+
+    fn collect_motif_hits(
+        fasta_path: &PathBuf,
+        motifs: Vec<RegexMotif>,
+        preload: bool,
+        interval_size: u64,
+        combine_strands: bool,
+        position_filter: Option<&StrandedPositionFilter<()>>,
+    ) -> (Vec<(u64, Strand, usize)>, Vec<Range<u64>>) {
+        let mut lookup = MotifLocationsLookup::from_paths(
+            fasta_path, false, None, motifs, preload,
+        )
+        .unwrap();
+        let contig_end = lookup.reader.contigs["chr1"];
+        let num_motifs = lookup.num_motifs();
+        let mut start = 0;
+        let mut hits = Vec::new();
+        let mut owners = Vec::new();
+        while start < contig_end {
+            let requested_end =
+                start.saturating_add(interval_size).min(contig_end);
+            let (focus_positions, actual_end) = lookup
+                .get_motif_positions(
+                    "chr1",
+                    0,
+                    contig_end as u32,
+                    start..requested_end,
+                    position_filter,
+                    combine_strands,
+                )
+                .unwrap();
+            let owner = start..actual_end as u64;
+            assert!(owner.end > owner.start);
+            hits.extend(decode_motif_mask(
+                focus_positions,
+                owner.clone(),
+                num_motifs,
+            ));
+            owners.push(owner.clone());
+            start = owner.end;
+        }
+        hits.sort_by_key(|(position, strand, motif_idx)| {
+            (*position, *strand, *motif_idx)
+        });
+        (hits, owners)
+    }
+
+    #[test]
+    fn fasta_subsequences_are_half_open_with_or_without_preload() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let fasta_path = write_fasta(temp_dir.path(), "ACGT");
+
+        for preload in [false, true] {
+            let reader =
+                HtsFastaHandle::from_file(&fasta_path, preload).unwrap();
+            for (start, end, expected) in [
+                (0, 0, ""),
+                (0, 1, "A"),
+                (1, 3, "CG"),
+                (3, 4, "T"),
+                (4, 4, ""),
+                (0, 4, "ACGT"),
+            ] {
+                assert_eq!(
+                    reader.get_sequence("chr1", start, end).unwrap(),
+                    expected,
+                    "preload={preload}, range={start}..{end}"
+                );
+            }
+            assert!(reader.get_sequence("chr1", 3, 2).is_err());
+            assert!(reader.get_sequence("chr1", 0, 5).is_err());
+        }
+    }
+
+    #[test]
+    fn motif_hits_are_interval_and_preload_invariant() {
+        struct Case<'a> {
+            sequence: &'a str,
+            motif: &'a str,
+            offset: usize,
+            expected: Vec<(u64, Strand, usize)>,
+        }
+
+        let cases = [
+            Case {
+                sequence: "ACGTCG",
+                motif: "CG",
+                offset: 0,
+                expected: vec![
+                    (1, Strand::Positive, 0),
+                    (2, Strand::Negative, 0),
+                    (4, Strand::Positive, 0),
+                    (5, Strand::Negative, 0),
+                ],
+            },
+            Case {
+                sequence: "GATCNNGATC",
+                motif: "GATC",
+                offset: 1,
+                expected: vec![
+                    (1, Strand::Positive, 0),
+                    (2, Strand::Negative, 0),
+                    (7, Strand::Positive, 0),
+                    (8, Strand::Negative, 0),
+                ],
+            },
+            Case {
+                sequence: "CGTACG",
+                motif: "CGT",
+                offset: 0,
+                expected: vec![
+                    (0, Strand::Positive, 0),
+                    (5, Strand::Negative, 0),
+                ],
+            },
+        ];
+
+        for case in cases {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let fasta_path = write_fasta(temp_dir.path(), case.sequence);
+            for preload in [false, true] {
+                for interval_size in [1, 2, 3, case.sequence.len() as u64, 100]
+                {
+                    let motif =
+                        RegexMotif::parse_string(case.motif, case.offset)
+                            .unwrap();
+                    let (observed, _) = collect_motif_hits(
+                        &fasta_path,
+                        vec![motif],
+                        preload,
+                        interval_size,
+                        false,
+                        None,
+                    );
+                    assert_eq!(
+                        observed, case.expected,
+                        "sequence={}, motif={} {}, preload={preload}, \
+                         interval_size={interval_size}",
+                        case.sequence, case.motif, case.offset
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn motif_position_filter_uses_global_stranded_anchors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let fasta_path = write_fasta(temp_dir.path(), "NNGATCNN");
+        let mut pos_positions = FxHashMap::default();
+        pos_positions
+            .insert(0, Lapper::new(vec![Iv { start: 3, stop: 4, val: () }]));
+        let mut neg_positions = FxHashMap::default();
+        neg_positions
+            .insert(0, Lapper::new(vec![Iv { start: 4, stop: 5, val: () }]));
+        let position_filter =
+            StrandedPositionFilter { pos_positions, neg_positions };
+        let motif = RegexMotif::parse_string("GATC", 1).unwrap();
+
+        for preload in [false, true] {
+            let (observed, _) = collect_motif_hits(
+                &fasta_path,
+                vec![motif.clone()],
+                preload,
+                1,
+                false,
+                Some(&position_filter),
+            );
+            assert_eq!(
+                observed,
+                vec![(3, Strand::Positive, 0), (4, Strand::Negative, 0),]
+            );
+        }
+    }
+
+    #[test]
+    fn combined_strand_lookup_preserves_boundary_extension() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let fasta_path = write_fasta(temp_dir.path(), "GATCNNNN");
+        let motif = RegexMotif::parse_string("GATC", 1).unwrap();
+
+        for preload in [false, true] {
+            let (observed, owners) = collect_motif_hits(
+                &fasta_path,
+                vec![motif.clone()],
+                preload,
+                2,
+                true,
+                None,
+            );
+            assert_eq!(owners, vec![0..3, 3..5, 5..7, 7..8]);
+            assert_eq!(
+                observed,
+                vec![(1, Strand::Positive, 0), (2, Strand::Negative, 0),]
+            );
+        }
+    }
+
+    #[test]
+    fn combined_strand_lookup_extends_to_the_actual_cgcg_pair() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let fasta_path = write_fasta(temp_dir.path(), "CGCGNN");
+        let motif = RegexMotif::parse_string("CGCG", 0).unwrap();
+
+        for preload in [false, true] {
+            for (interval_size, expected_owners) in [
+                (1, vec![0..4, 4..5, 5..6]),
+                (2, vec![0..4, 4..6]),
+                (3, vec![0..4, 4..6]),
+                (6, vec![0..6]),
+            ] {
+                let (observed, owners) = collect_motif_hits(
+                    &fasta_path,
+                    vec![motif.clone()],
+                    preload,
+                    interval_size,
+                    true,
+                    None,
+                );
+                assert_eq!(owners, expected_owners);
+                assert_eq!(
+                    observed,
+                    vec![(0, Strand::Positive, 0), (3, Strand::Negative, 0),],
+                    "preload={preload}, interval_size={interval_size}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn combined_strand_lookup_closes_over_every_new_boundary_pair() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let fasta_path = write_fasta(temp_dir.path(), "CGCGCGNN");
+        let motif = RegexMotif::parse_string("CGCG", 0).unwrap();
+
+        for preload in [false, true] {
+            let (observed, owners) = collect_motif_hits(
+                &fasta_path,
+                vec![motif.clone()],
+                preload,
+                1,
+                true,
+                None,
+            );
+            assert_eq!(owners, vec![0..6, 6..7, 7..8]);
+            assert_eq!(
+                observed,
+                vec![
+                    (0, Strand::Positive, 0),
+                    (2, Strand::Positive, 0),
+                    (3, Strand::Negative, 0),
+                    (5, Strand::Negative, 0),
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn combined_strand_lookup_owns_and_filters_pairs_by_positive_anchor() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let sequence = format!("{}CGCG{}", "N".repeat(38), "N".repeat(28));
+        let fasta_path = write_fasta(temp_dir.path(), &sequence);
+        let motif = RegexMotif::parse_string("CGCG", 0).unwrap();
+
+        for preload in [false, true] {
+            let mut lookup = MotifLocationsLookup::from_paths(
+                &fasta_path,
+                false,
+                None,
+                vec![motif.clone()],
+                preload,
+            )
+            .unwrap();
+
+            // The reverse anchor at 41 is not an independently owned hit when
+            // its positive pair anchor at 38 is before the selected region.
+            let (focus_positions, actual_end) = lookup
+                .get_motif_positions("chr1", 0, 62, 40..62, None, true)
+                .unwrap();
+            assert_eq!(actual_end, 62);
+            assert!(decode_motif_mask(focus_positions, 40..62, 1).is_empty());
+
+            let mut pos_positions = FxHashMap::default();
+            pos_positions.insert(
+                0,
+                Lapper::new(vec![Iv { start: 38, stop: 39, val: () }]),
+            );
+            let positive_only = StrandedPositionFilter {
+                pos_positions,
+                neg_positions: FxHashMap::default(),
+            };
+            let (focus_positions, actual_end) = lookup
+                .get_motif_positions(
+                    "chr1",
+                    0,
+                    62,
+                    38..62,
+                    Some(&positive_only),
+                    true,
+                )
+                .unwrap();
+            assert_eq!(actual_end, 62);
+            assert_eq!(
+                decode_motif_mask(focus_positions, 38..62, 1),
+                vec![(38, Strand::Positive, 0), (41, Strand::Negative, 0),]
+            );
+
+            let mut neg_positions = FxHashMap::default();
+            neg_positions.insert(
+                0,
+                Lapper::new(vec![Iv { start: 41, stop: 42, val: () }]),
+            );
+            let negative_only = StrandedPositionFilter {
+                pos_positions: FxHashMap::default(),
+                neg_positions,
+            };
+            let (focus_positions, actual_end) = lookup
+                .get_motif_positions(
+                    "chr1",
+                    0,
+                    62,
+                    38..62,
+                    Some(&negative_only),
+                    true,
+                )
+                .unwrap();
+            assert_eq!(actual_end, 62);
+            assert!(decode_motif_mask(focus_positions, 38..62, 1).is_empty());
+        }
+    }
 
     #[test]
     fn test_hts_fasta_reader() {

--- a/modkit-core/src/fasta.rs
+++ b/modkit-core/src/fasta.rs
@@ -265,15 +265,16 @@ impl MotifLocationsLookup {
         Ok(mask)
     }
 
-    /// Find complete palindromic-motif anchor pairs owned by their positive
-    /// anchor. A combined-strand output row is written at that positive
-    /// coordinate, so the region and any stranded position filter must select
-    /// that coordinate; the paired negative anchor is then admitted
-    /// atomically even when a strand-specific filter does not select it.
+    /// Find complete palindromic-motif anchor pairs whose positive anchor is
+    /// in `positive_scan`. A combined-strand output row is written at that
+    /// positive coordinate, so any stranded position filter must select it;
+    /// the paired negative anchor is then admitted atomically even when a
+    /// strand-specific filter does not select it.
     fn get_combined_motif_pairs(
         &self,
         contig: &str,
-        positive_owner: std::ops::Range<u64>,
+        positive_scan: std::ops::Range<u64>,
+        owner_start: u64,
         owner_limit: u64,
         tid: u32,
         stranded_position_filter: Option<&StrandedPositionFilter<()>>,
@@ -281,19 +282,20 @@ impl MotifLocationsLookup {
         let ref_end = *self.reader.contigs.get(contig).ok_or_else(|| {
             MkError::ContigMissing(format!("{contig} not in FASTA index"))
         })?;
-        if positive_owner.start > positive_owner.end
-            || positive_owner.end > owner_limit
+        if owner_start > positive_scan.start
+            || positive_scan.start > positive_scan.end
+            || positive_scan.end > owner_limit
             || owner_limit > ref_end
         {
             return Err(MkError::InvalidReferenceCoordinates);
         }
-        if positive_owner.is_empty() {
+        if positive_scan.is_empty() {
             return Ok(Vec::new());
         }
 
         let context = self.longest_motif_length.saturating_sub(1);
-        let fetch_start = positive_owner.start.saturating_sub(context);
-        let fetch_end = positive_owner.end.saturating_add(context).min(ref_end);
+        let fetch_start = positive_scan.start.saturating_sub(context);
+        let fetch_end = positive_scan.end.saturating_add(context).min(ref_end);
         let seq = self.reader.get_sequence(contig, fetch_start, fetch_end)?;
         let seq = if self.mask { seq } else { seq.to_ascii_uppercase() };
 
@@ -311,7 +313,7 @@ impl MotifLocationsLookup {
                 else {
                     continue;
                 };
-                if !positive_owner.contains(&positive_position)
+                if !positive_scan.contains(&positive_position)
                     || stranded_position_filter.is_some_and(|spf| {
                         !spf.contains(
                             tid as i32,
@@ -333,10 +335,9 @@ impl MotifLocationsLookup {
                     continue;
                 };
 
-                // Both anchors must be in the same selected reference region
-                // and owner. In particular, never expose a reverse anchor
-                // whose positive owner is before the region start.
-                if negative_position < positive_owner.start
+                // Both anchors must be in the same selected reference region,
+                // even when this scan window starts inside that region.
+                if negative_position < owner_start
                     || negative_position >= owner_limit
                 {
                     continue;
@@ -375,50 +376,74 @@ impl MotifLocationsLookup {
             ));
         }
 
-        let mut end = range.end;
-        let (mask, end) = loop {
-            let pairs = self.get_combined_motif_pairs(
+        // Discover a little past the requested owner so an ordinary boundary
+        // pair closes in one scan. If overlapping pairs carry the closure
+        // farther, scan disjoint lookahead windows that grow geometrically.
+        // This preserves exact transitive ownership without repeatedly
+        // fetching and searching the full growing owner prefix.
+        let mut closure_end = range.end;
+        let mut scan_start = range.start;
+        let mut window_size = self.longest_motif_length.max(1);
+        let mut scan_end =
+            range.end.saturating_add(window_size).min(owner_limit);
+        let mut pairs = Vec::new();
+        loop {
+            let mut new_pairs = self.get_combined_motif_pairs(
                 contig,
-                range.start..end,
+                scan_start..scan_end,
+                range.start,
                 owner_limit,
                 tid,
                 stranded_position_filter,
             )?;
-            let required_end = pairs
-                .iter()
-                .filter_map(|(positive, negative, _)| {
-                    positive.max(negative).checked_add(1)
-                })
-                .max()
-                .unwrap_or(end);
-            if required_end > end {
-                debug!(
-                    "extending combined motif owner from {end} to \
-                     {required_end}, contig={contig}, range={range:?}"
-                );
-                end = required_end;
-                continue;
+            new_pairs.sort_unstable_by_key(|(positive, _, _)| *positive);
+            for (positive, negative, _) in &new_pairs {
+                if *positive >= closure_end {
+                    break;
+                }
+                if let Some(pair_end) = positive.max(negative).checked_add(1) {
+                    closure_end = closure_end.max(pair_end);
+                }
+            }
+            pairs.extend(new_pairs);
+
+            if closure_end <= scan_end {
+                break;
             }
 
-            let mut mask =
-                bitvec![0; (end - range.start) as usize * bits_per_pos];
-            for (positive, negative, motif_idx) in pairs {
-                let positive_local = (positive - range.start) as usize;
-                let negative_local = (negative - range.start) as usize;
-                mask.set((positive_local * bits_per_pos) + motif_idx, true);
-                mask.set(
-                    (negative_local * bits_per_pos) + num_motifs + motif_idx,
-                    true,
-                );
-            }
-            break (mask, end);
-        };
+            let previous_scan_end = scan_end;
+            scan_start = scan_end;
+            window_size = window_size.saturating_mul(2);
+            scan_end = scan_end
+                .saturating_add(window_size)
+                .max(closure_end)
+                .min(owner_limit);
+            debug!(
+                "growing combined motif lookahead from {previous_scan_end} to \
+                 {scan_end} for owner closure {closure_end}, contig={contig}, \
+                 range={range:?}"
+            );
+            debug_assert!(scan_end > previous_scan_end);
+        }
+
+        pairs.retain(|(positive, _, _)| *positive < closure_end);
+        let mut mask =
+            bitvec![0; (closure_end - range.start) as usize * bits_per_pos];
+        for (positive, negative, motif_idx) in pairs {
+            let positive_local = (positive - range.start) as usize;
+            let negative_local = (negative - range.start) as usize;
+            mask.set((positive_local * bits_per_pos) + motif_idx, true);
+            mask.set(
+                (negative_local * bits_per_pos) + num_motifs + motif_idx,
+                true,
+            );
+        }
         Ok((
             FocusPositions2::MotifMask {
                 mask,
                 num_motifs: self.num_motifs() as u8,
             },
-            end as u32,
+            closure_end as u32,
         ))
     }
 

--- a/modkit-core/src/pileup/subcommand.rs
+++ b/modkit-core/src/pileup/subcommand.rs
@@ -57,6 +57,18 @@ use crate::writers::{
     PhasedBedMethylWriter, PileupWriter,
 };
 
+const MAX_PILEUP_MOTIFS: usize = u8::BITS as usize;
+
+fn validate_motif_capacity(motif_count: usize) -> anyhow::Result<()> {
+    if motif_count > MAX_PILEUP_MOTIFS {
+        bail!(
+            "pileup supports at most {MAX_PILEUP_MOTIFS} motifs because motif \
+             membership is stored in an 8-bit mask; received {motif_count}"
+        )
+    }
+    Ok(())
+}
+
 #[derive(Args)]
 #[command(arg_required_else_help = true)]
 pub struct ModBamPileup {
@@ -304,10 +316,11 @@ pub struct ModBamPileup {
     /// used, the resulting output BED file will indicate the motif in the
     /// "name" field as <mod_code>,<motif>,<offset>. For example, given
     /// `--motif CGCG 2 --motif CG 0` there will be output lines with name
-    /// fields such as "m,CG,0" and "m,CGCG,2". To use
-    /// `--combine-strands`, exactly one motif must be supplied. It must be
-    /// reverse-complement palindromic, and the reverse-strand anchor must not
-    /// precede the forward-strand anchor, or an error will be raised.
+    /// fields such as "m,CG,0" and "m,CGCG,2". At most eight motifs are
+    /// supported, including motifs added by `--cpg` or `--modified-bases`.
+    /// To use `--combine-strands`, exactly one motif must be supplied. It must
+    /// be reverse-complement palindromic, and the reverse-strand anchor must
+    /// not precede the forward-strand anchor, or an error will be raised.
     #[clap(help_heading = "Modified Base Options")]
     #[arg(long, action = clap::ArgAction::Append, num_args = 2, requires = "reference_fasta")]
     motif: Option<Vec<String>>,
@@ -586,6 +599,7 @@ impl ModBamPileup {
     ) -> anyhow::Result<(Option<Presets>, Option<Vec<RegexMotif>>)> {
         let mut regex_motifs =
             self.parse_user_motifs().transpose()?.unwrap_or_else(Vec::new);
+        validate_motif_capacity(regex_motifs.len())?;
         Self::validate_combine_strands_motifs(
             self.combine_strands,
             &regex_motifs,
@@ -600,7 +614,7 @@ impl ModBamPileup {
             info!(
                 "more than one motif requires use of general pileup processor"
             );
-            let motif_primary_bases = regex_motifs
+            let mut motif_primary_bases = regex_motifs
                 .iter()
                 .map(|mot| mot.motif_info.primary_base)
                 .collect::<HashSet<DnaBase>>();
@@ -608,7 +622,7 @@ impl ModBamPileup {
                 for primary_base in
                     modified_bases.iter().map(|x| x.primary_base)
                 {
-                    if !motif_primary_bases.contains(&primary_base) {
+                    if motif_primary_bases.insert(primary_base) {
                         info!(
                             "adding single-base motif: '{} 0'",
                             primary_base.char()
@@ -623,6 +637,7 @@ impl ModBamPileup {
                     }
                 }
             }
+            validate_motif_capacity(regex_motifs.len())?;
             return Ok((None, Some(regex_motifs)));
         }
         if let Some(modified_bases) = self.modified_bases.as_ref() {
@@ -1707,6 +1722,20 @@ impl ModBamPileup {
         aggregator.join().expect("aggregator theread paniced");
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn motif_capacity_accepts_eight_and_rejects_nine() {
+        assert!(validate_motif_capacity(8).is_ok());
+
+        let error = validate_motif_capacity(9).unwrap_err().to_string();
+        assert!(error.contains("at most 8 motifs"));
+        assert!(error.contains("received 9"));
     }
 }
 

--- a/modkit-core/src/pileup/subcommand.rs
+++ b/modkit-core/src/pileup/subcommand.rs
@@ -304,10 +304,10 @@ pub struct ModBamPileup {
     /// used, the resulting output BED file will indicate the motif in the
     /// "name" field as <mod_code>,<motif>,<offset>. For example, given
     /// `--motif CGCG 2 --motif CG 0` there will be output lines with name
-    /// fields such as "m,CG,0" and "m,CGCG,2". To use this option with
-    /// `--combine-strands`, all motifs must be reverse-complement
-    /// palindromic and the reverse-strand anchor must not precede the
-    /// forward-strand anchor, or an error will be raised.
+    /// fields such as "m,CG,0" and "m,CGCG,2". To use
+    /// `--combine-strands`, exactly one motif must be supplied. It must be
+    /// reverse-complement palindromic, and the reverse-strand anchor must not
+    /// precede the forward-strand anchor, or an error will be raised.
     #[clap(help_heading = "Modified Base Options")]
     #[arg(long, action = clap::ArgAction::Append, num_args = 2, requires = "reference_fasta")]
     motif: Option<Vec<String>>,
@@ -439,26 +439,44 @@ impl ModBamPileup {
         motifs == &[RegexMotif::parse_string("CG", 0).unwrap()]
     }
 
-    fn validate_combine_strands_anchor_order(
+    fn validate_combine_strands_motifs(
         combine_strands: bool,
         motifs: &[RegexMotif],
     ) -> anyhow::Result<()> {
-        if combine_strands {
-            for motif in motifs {
-                let motif_info = motif.motif_info;
-                if motif_info.reverse_offset < motif_info.forward_offset {
-                    bail!(
-                        "cannot combine strands for motif '{} {}': \
-                         reverse-strand anchor offset {} precedes \
-                         forward-strand anchor offset {}; the reverse anchor \
-                         must not precede the forward anchor",
-                        motif.raw_motif,
-                        motif_info.forward_offset,
-                        motif_info.reverse_offset,
-                        motif_info.forward_offset,
-                    );
-                }
-            }
+        if !combine_strands {
+            return Ok(());
+        }
+
+        let motif = match motifs {
+            [motif] => motif,
+            [] => bail!(
+                "need to provide one reverse-complement palindromic motif to \
+                 combine strands"
+            ),
+            _ => bail!(
+                "multiple motifs and combine-strands not currently supported"
+            ),
+        };
+        if !motif.is_palendrome() {
+            bail!(
+                "cannot combine strands for motif '{} {}': motif must be \
+                 reverse-complement palindromic",
+                motif.raw_motif,
+                motif.motif_info.forward_offset,
+            );
+        }
+
+        let motif_info = motif.motif_info;
+        if motif_info.reverse_offset < motif_info.forward_offset {
+            bail!(
+                "cannot combine strands for motif '{} {}': reverse-strand \
+                 anchor offset {} precedes forward-strand anchor offset {}; \
+                 the reverse anchor must not precede the forward anchor",
+                motif.raw_motif,
+                motif_info.forward_offset,
+                motif_info.reverse_offset,
+                motif_info.forward_offset,
+            );
         }
         Ok(())
     }
@@ -568,6 +586,10 @@ impl ModBamPileup {
     ) -> anyhow::Result<(Option<Presets>, Option<Vec<RegexMotif>>)> {
         let mut regex_motifs =
             self.parse_user_motifs().transpose()?.unwrap_or_else(Vec::new);
+        Self::validate_combine_strands_motifs(
+            self.combine_strands,
+            &regex_motifs,
+        )?;
         if regex_motifs.len() > 1 {
             if self.combine_strands {
                 bail!(
@@ -603,10 +625,6 @@ impl ModBamPileup {
             }
             return Ok((None, Some(regex_motifs)));
         }
-        Self::validate_combine_strands_anchor_order(
-            self.combine_strands,
-            &regex_motifs,
-        )?;
         if let Some(modified_bases) = self.modified_bases.as_ref() {
             let modified_bases = modified_bases
                 .iter()

--- a/modkit-core/src/pileup/subcommand.rs
+++ b/modkit-core/src/pileup/subcommand.rs
@@ -306,7 +306,8 @@ pub struct ModBamPileup {
     /// `--motif CGCG 2 --motif CG 0` there will be output lines with name
     /// fields such as "m,CG,0" and "m,CGCG,2". To use this option with
     /// `--combine-strands`, all motifs must be reverse-complement
-    /// palindromic or an error will be raised.
+    /// palindromic and the reverse-strand anchor must not precede the
+    /// forward-strand anchor, or an error will be raised.
     #[clap(help_heading = "Modified Base Options")]
     #[arg(long, action = clap::ArgAction::Append, num_args = 2, requires = "reference_fasta")]
     motif: Option<Vec<String>>,
@@ -436,6 +437,30 @@ impl ModBamPileup {
 
     fn use_cpg(motifs: &[RegexMotif]) -> bool {
         motifs == &[RegexMotif::parse_string("CG", 0).unwrap()]
+    }
+
+    fn validate_combine_strands_anchor_order(
+        combine_strands: bool,
+        motifs: &[RegexMotif],
+    ) -> anyhow::Result<()> {
+        if combine_strands {
+            for motif in motifs {
+                let motif_info = motif.motif_info;
+                if motif_info.reverse_offset < motif_info.forward_offset {
+                    bail!(
+                        "cannot combine strands for motif '{} {}': \
+                         reverse-strand anchor offset {} precedes \
+                         forward-strand anchor offset {}; the reverse anchor \
+                         must not precede the forward anchor",
+                        motif.raw_motif,
+                        motif_info.forward_offset,
+                        motif_info.reverse_offset,
+                        motif_info.forward_offset,
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     fn is_5mc_5hmc_cpg(
@@ -578,6 +603,10 @@ impl ModBamPileup {
             }
             return Ok((None, Some(regex_motifs)));
         }
+        Self::validate_combine_strands_anchor_order(
+            self.combine_strands,
+            &regex_motifs,
+        )?;
         if let Some(modified_bases) = self.modified_bases.as_ref() {
             let modified_bases = modified_bases
                 .iter()
@@ -640,11 +669,7 @@ impl ModBamPileup {
                          motif to combine strands"
                     )
                 }
-                let motif_offset = regex_motifs[0].motif_info.offset();
-                if motif_offset < 0 {
-                    bail!("invalid palindromic motif");
-                }
-                let motif_offset = motif_offset as u32;
+                let motif_offset = regex_motifs[0].motif_info.offset() as u32;
                 let motif_bases = [
                     regex_motifs[0].motif_info.primary_base,
                     DnaBase::C,

--- a/modkit-core/src/pileup/subcommand.rs
+++ b/modkit-core/src/pileup/subcommand.rs
@@ -1029,6 +1029,9 @@ impl ModBamPileup {
                 Presets::DnaCpGCombineStrands { .. } => {
                     (PileupNumericOptions::Passthrough, true)
                 }
+                Presets::DynamicAllContext {
+                    motif_offset: Some(_), ..
+                } => (PileupNumericOptions::Passthrough, true),
                 _ => (PileupNumericOptions::Passthrough, false),
             },
             None => {

--- a/modkit/tests/test_pileup.rs
+++ b/modkit/tests/test_pileup.rs
@@ -5,10 +5,11 @@ use rust_htslib::bam::header::HeaderRecord;
 use rust_htslib::bam::record::{Aux, Cigar, CigarString};
 use rust_htslib::bam::{Format, Header, Record, Writer as BamWriter};
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
 
 use common::{check_against_expected_text_file, run_modkit};
 use mod_kit::dmr::bedmethyl::BedMethylLine;
@@ -1193,6 +1194,168 @@ fn test_pileup_motifs_cg0_cgcg2() {
         temp_file.to_str().unwrap(),
         "../tests/resources/cgcg2_cg0_test2.bed",
     );
+}
+
+fn run_pileup_with_overlapping_motifs(
+    output_path: &Path,
+    motif_count: usize,
+    modified_base: &str,
+    extra_modified_base: Option<&str>,
+    add_cpg: bool,
+    extra_motif: Option<(&str, &str)>,
+) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_modkit"));
+    command.args([
+        "pileup",
+        "../tests/resources/CG_5mC_20230207_1700_6A_PAG66026_3c0abf27_oligo_741_adapters_modcalls_0th_sort_10_reads.bam",
+        output_path.to_str().unwrap(),
+        "--no-filtering",
+        "--ref",
+        "../tests/resources/CGI_ladder_3.6kb_ref.fa",
+        "--region",
+        "oligo_741_adapters:22-62",
+        "--modified-bases",
+        modified_base,
+    ]);
+    if let Some(extra_modified_base) = extra_modified_base {
+        command.arg(extra_modified_base);
+    }
+    command.args(["--threads", "1", "--io-threads", "1"]);
+
+    for (motif, offset) in [
+        ("CGG", "0"),
+        ("CGGG", "0"),
+        ("TCG", "1"),
+        ("CTCG", "2"),
+        ("GCTCG", "3"),
+        ("TGCTCG", "4"),
+        ("TTGCTCG", "5"),
+        ("ATTGCTCG", "6"),
+    ]
+    .into_iter()
+    .take(motif_count)
+    {
+        command.args(["--motif", motif, offset]);
+    }
+    if let Some((motif, offset)) = extra_motif {
+        command.args(["--motif", motif, offset]);
+    }
+    if add_cpg {
+        command.arg("--cpg");
+    }
+
+    command.output().unwrap()
+}
+
+#[test]
+fn test_pileup_rejects_more_than_eight_motifs() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let eight_motifs_path = temp_dir.path().join("eight.bed");
+    let output = run_pileup_with_overlapping_motifs(
+        &eight_motifs_path,
+        8,
+        "5mC",
+        None,
+        false,
+        None,
+    );
+    assert!(
+        output.status.success(),
+        "eight motifs should be accepted: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let observed_labels =
+        BufReader::new(File::open(&eight_motifs_path).unwrap())
+            .lines()
+            .map(|line| line.unwrap().split('\t').nth(3).unwrap().to_string())
+            .collect::<BTreeSet<_>>();
+    let expected_labels = [
+        "m,CGG,0",
+        "m,CGGG,0",
+        "m,TCG,1",
+        "m,CTCG,2",
+        "m,GCTCG,3",
+        "m,TGCTCG,4",
+        "m,TTGCTCG,5",
+        "m,ATTGCTCG,6",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect::<BTreeSet<_>>();
+    assert_eq!(observed_labels, expected_labels);
+
+    let deduplicated_auto_motif_path =
+        temp_dir.path().join("deduplicated-auto-motif.bed");
+    let output = run_pileup_with_overlapping_motifs(
+        &deduplicated_auto_motif_path,
+        7,
+        "m6A",
+        Some("2OmeA"),
+        false,
+        None,
+    );
+    assert!(
+        output.status.success(),
+        "two codes for one missing primary base should add one motif: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let automatically_added_labels =
+        BufReader::new(File::open(&deduplicated_auto_motif_path).unwrap())
+            .lines()
+            .map(|line| line.unwrap().split('\t').nth(3).unwrap().to_string())
+            .collect::<BTreeSet<_>>();
+    assert!(automatically_added_labels.contains("a,A,0"));
+
+    for (filename, modified_base, add_cpg, extra_motif) in [
+        ("ninth-explicit.bed", "5mC", false, Some(("CGCG", "0"))),
+        ("ninth-cpg.bed", "5mC", true, None),
+        ("ninth-added-base.bed", "m6A", false, None),
+    ] {
+        let output_path = temp_dir.path().join(filename);
+        let output = run_pileup_with_overlapping_motifs(
+            &output_path,
+            8,
+            modified_base,
+            None,
+            add_cpg,
+            extra_motif,
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "nine motifs should fail");
+        assert!(
+            stderr.contains("pileup supports at most 8 motifs")
+                && stderr.contains("received 9"),
+            "expected a clear motif-capacity diagnostic, got: {stderr}"
+        );
+        assert!(
+            !output_path.exists(),
+            "motif validation should happen before creating output"
+        );
+
+        let sentinel = b"existing output\n";
+        std::fs::write(&output_path, sentinel).unwrap();
+        let output = run_pileup_with_overlapping_motifs(
+            &output_path,
+            8,
+            modified_base,
+            None,
+            add_cpg,
+            extra_motif,
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "nine motifs should fail");
+        assert!(
+            stderr.contains("pileup supports at most 8 motifs")
+                && stderr.contains("received 9"),
+            "expected a clear motif-capacity diagnostic, got: {stderr}"
+        );
+        assert_eq!(
+            std::fs::read(&output_path).unwrap(),
+            sentinel,
+            "motif validation should happen before changing output"
+        );
+    }
 }
 
 #[test]

--- a/modkit/tests/test_pileup.rs
+++ b/modkit/tests/test_pileup.rs
@@ -1,17 +1,200 @@
 use anyhow::Context;
 use itertools::Itertools;
 use rust_htslib::bam;
+use rust_htslib::bam::header::HeaderRecord;
+use rust_htslib::bam::record::{Aux, Cigar, CigarString};
+use rust_htslib::bam::{Format, Header, Record, Writer as BamWriter};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
 
 use common::{check_against_expected_text_file, run_modkit};
 use mod_kit::dmr::bedmethyl::BedMethylLine;
 use mod_kit::mod_base_code::{ModCodeRepr, METHYL_CYTOSINE};
 
 mod common;
+
+fn write_motif_boundary_fixture(root: &Path) -> (PathBuf, PathBuf) {
+    let bam_path = root.join("motif-boundaries.bam");
+    let fasta_path = root.join("motif-boundaries.fa");
+
+    let mut header = Header::new();
+    let mut sq = HeaderRecord::new(b"SQ");
+    sq.push_tag(b"SN", "chr1");
+    sq.push_tag(b"LN", 6);
+    header.push_record(&sq);
+
+    let mut writer =
+        BamWriter::from_path(&bam_path, &header, Format::Bam).unwrap();
+    for (name, reverse) in [("forward", false), ("reverse", true)] {
+        let cigar = CigarString(vec![Cigar::Match(6)]);
+        let mut record = Record::new();
+        record.set(name.as_bytes(), Some(&cigar), b"ACGTCG", &[30; 6]);
+        record.set_tid(0);
+        record.set_pos(0);
+        record.set_mapq(60);
+        if reverse {
+            record.set_flags(16);
+        }
+        record.push_aux(b"MM", Aux::String("C+m?,0,0;")).unwrap();
+        record.push_aux(b"ML", Aux::ArrayU8((&[255, 255][..]).into())).unwrap();
+        record.push_aux(b"MN", Aux::U32(6)).unwrap();
+        record.push_aux(b"NM", Aux::U32(0)).unwrap();
+        writer.write(&record).unwrap();
+    }
+    drop(writer);
+    bam::index::build(bam_path.clone(), None, bam::index::Type::Bai, 1)
+        .unwrap();
+
+    File::create(&fasta_path).unwrap().write_all(b">chr1\nACGTCG\n").unwrap();
+    File::create(root.join("motif-boundaries.fa.fai"))
+        .unwrap()
+        .write_all(b"chr1\t6\t6\t6\t7\n")
+        .unwrap();
+
+    (bam_path, fasta_path)
+}
+
+fn run_motif_boundary_pileup(
+    root: &Path,
+    bam_path: &Path,
+    fasta_path: &Path,
+    preload: bool,
+    interval_size: usize,
+) -> Vec<u8> {
+    let preload_name = if preload { "preload" } else { "faidx" };
+    let output_path =
+        root.join(format!("motif-{preload_name}-{interval_size}.bed"));
+    let interval_size = interval_size.to_string();
+    let mut args = vec![
+        "pileup",
+        bam_path.to_str().unwrap(),
+        output_path.to_str().unwrap(),
+        "--ref",
+        fasta_path.to_str().unwrap(),
+        "--motif",
+        "CG",
+        "0",
+        "--modified-bases",
+        "C:m",
+        "--no-filtering",
+        "--interval-size",
+        &interval_size,
+        "--threads",
+        "1",
+        "--suppress-progress",
+    ];
+    if preload {
+        args.push("--preload-references");
+    }
+    run_modkit(&args).unwrap();
+    std::fs::read(output_path).unwrap()
+}
+
+fn run_cgcg0_combined_pileup(
+    root: &Path,
+    optimized: bool,
+    region: &str,
+    interval_size: usize,
+) -> Vec<u8> {
+    let processor = if optimized { "optimized" } else { "generic" };
+    let output_path = root.join(format!(
+        "cgcg0-{processor}-{}-{interval_size}.bed",
+        region.replace(':', "-")
+    ));
+    let interval_size = interval_size.to_string();
+    let mut args = vec![
+        "pileup",
+        "../tests/resources/CG_5mC_20230207_1700_6A_PAG66026_3c0abf27_oligo_741_adapters_modcalls_0th_sort_10_reads.bam",
+        output_path.to_str().unwrap(),
+        "--motif",
+        "CGCG",
+        "0",
+        "--combine-strands",
+        "--no-filtering",
+        "--ref",
+        "../tests/resources/CGI_ladder_3.6kb_ref.fa",
+        "--region",
+        region,
+        "--interval-size",
+        &interval_size,
+        "--threads",
+        "1",
+        "--suppress-progress",
+    ];
+    if optimized {
+        args.extend(["--modified-bases", "C:m"]);
+    }
+    run_modkit(&args).unwrap();
+    std::fs::read(output_path).unwrap()
+}
+
+#[test]
+fn test_pileup_motif_boundaries_are_preload_and_interval_invariant() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root = temp_dir.path();
+    let (bam_path, fasta_path) = write_motif_boundary_fixture(root);
+    let expected = concat!(
+        "chr1\t1\t2\tm\t1\t+\t1\t2\t255,0,0\t1\t100.00\t1\t0\t0\t0\t0\t0\t0\n",
+        "chr1\t2\t3\tm\t1\t-\t2\t3\t255,0,0\t1\t100.00\t1\t0\t0\t0\t0\t0\t0\n",
+        "chr1\t4\t5\tm\t1\t+\t4\t5\t255,0,0\t1\t100.00\t1\t0\t0\t0\t0\t0\t0\n",
+        "chr1\t5\t6\tm\t1\t-\t5\t6\t255,0,0\t1\t100.00\t1\t0\t0\t0\t0\t0\t0\n",
+    );
+
+    for preload in [false, true] {
+        for interval_size in [1, 2, 3, 6, 100] {
+            let observed = run_motif_boundary_pileup(
+                root,
+                &bam_path,
+                &fasta_path,
+                preload,
+                interval_size,
+            );
+            assert_eq!(
+                observed,
+                expected.as_bytes(),
+                "preload={preload}, interval_size={interval_size}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_cgcg0_combined_optimized_and_generic_are_interval_invariant() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let expected = b"oligo_741_adapters\t38\t39\tm\t11\t.\t38\t39\t255,0,0\t11\t100.00\t11\t0\t0\t1\t0\t0\t0\n";
+
+    for interval_size in [1, 2, 3, 40] {
+        let optimized = run_cgcg0_combined_pileup(
+            temp_dir.path(),
+            true,
+            "oligo_741_adapters:22-62",
+            interval_size,
+        );
+        let generic = run_cgcg0_combined_pileup(
+            temp_dir.path(),
+            false,
+            "oligo_741_adapters:22-62",
+            interval_size,
+        );
+        assert_eq!(optimized, expected, "optimized interval={interval_size}");
+        assert_eq!(generic, expected, "generic interval={interval_size}");
+    }
+
+    // The only CGCG0 pair in this span is +38/-41. Its positive owner is
+    // before the region, so neither processor may fabricate a row at 40.
+    for optimized in [false, true] {
+        let observed = run_cgcg0_combined_pileup(
+            temp_dir.path(),
+            optimized,
+            "oligo_741_adapters:40-62",
+            2,
+        );
+        assert!(observed.is_empty(), "optimized={optimized}");
+    }
+}
 
 #[test]
 fn test_pileup_help() {

--- a/modkit/tests/test_pileup.rs
+++ b/modkit/tests/test_pileup.rs
@@ -131,9 +131,9 @@ fn run_cgcg0_combined_pileup(
     std::fs::read(output_path).unwrap()
 }
 
-fn run_negative_combine_anchor_pileup(
+fn run_combine_motif_validation_pileup(
     output_path: &Path,
-    motif_offset: &str,
+    motifs: &[(&str, &str)],
     optimized: bool,
 ) -> std::process::Output {
     let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_modkit"));
@@ -141,9 +141,6 @@ fn run_negative_combine_anchor_pileup(
         "pileup",
         "../tests/resources/CG_5mC_20230207_1700_6A_PAG66026_3c0abf27_oligo_741_adapters_modcalls_0th_sort_10_reads.bam",
         output_path.to_str().unwrap(),
-        "--motif",
-        "CGCG",
-        motif_offset,
         "--combine-strands",
         "--no-filtering",
         "--ref",
@@ -156,6 +153,9 @@ fn run_negative_combine_anchor_pileup(
         "1",
         "--suppress-progress",
     ]);
+    for (motif, offset) in motifs {
+        command.args(["--motif", motif, offset]);
+    }
     if optimized {
         command.args(["--modified-bases", "C:m"]);
     }
@@ -239,9 +239,9 @@ fn test_negative_combine_anchor_is_rejected_before_opening_output() {
                 .path()
                 .join(format!("cgcg{motif_offset}-{processor}.bed"));
 
-            let output = run_negative_combine_anchor_pileup(
+            let output = run_combine_motif_validation_pileup(
                 &output_path,
-                motif_offset,
+                &[("CGCG", motif_offset)],
                 optimized,
             );
             let diagnostics = format!(
@@ -271,9 +271,9 @@ fn test_negative_combine_anchor_is_rejected_before_opening_output() {
             );
 
             std::fs::write(&output_path, sentinel).unwrap();
-            let output = run_negative_combine_anchor_pileup(
+            let output = run_combine_motif_validation_pileup(
                 &output_path,
-                motif_offset,
+                &[("CGCG", motif_offset)],
                 optimized,
             );
             assert!(
@@ -287,6 +287,86 @@ fn test_negative_combine_anchor_is_rejected_before_opening_output() {
             );
         }
     }
+}
+
+fn assert_invalid_combine_motif_configuration_preserves_output(
+    label: &str,
+    motifs: &[(&str, &str)],
+    expected_diagnostic: &str,
+) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let sentinel = b"existing output must remain unchanged\n";
+    for optimized in [false, true] {
+        let processor = if optimized { "optimized" } else { "generic" };
+        let output_path =
+            temp_dir.path().join(format!("{label}-{processor}.bed"));
+
+        let output = run_combine_motif_validation_pileup(
+            &output_path,
+            motifs,
+            optimized,
+        );
+        let diagnostics = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            !output.status.success(),
+            "{label} unexpectedly succeeded with {processor}"
+        );
+        assert!(
+            diagnostics.contains(expected_diagnostic),
+            "unexpected {processor} diagnostics for {label}: {diagnostics}"
+        );
+        assert!(
+            !output_path.exists(),
+            "invalid {label} {processor} request created its output"
+        );
+
+        std::fs::write(&output_path, sentinel).unwrap();
+        let output = run_combine_motif_validation_pileup(
+            &output_path,
+            motifs,
+            optimized,
+        );
+        assert!(
+            !output.status.success(),
+            "{label} unexpectedly succeeded with {processor}"
+        );
+        assert_eq!(
+            std::fs::read(&output_path).unwrap(),
+            sentinel,
+            "invalid {label} {processor} request truncated its output"
+        );
+    }
+}
+
+#[test]
+fn test_missing_combine_motif_is_rejected_before_output() {
+    assert_invalid_combine_motif_configuration_preserves_output(
+        "no-motif",
+        &[],
+        "combine strands",
+    );
+}
+
+#[test]
+fn test_non_palindromic_combine_motif_is_rejected_before_output() {
+    assert_invalid_combine_motif_configuration_preserves_output(
+        "non-palindrome",
+        &[("CAT", "0")],
+        "combine strands",
+    );
+}
+
+#[test]
+fn test_multiple_combine_motifs_are_rejected_before_output() {
+    assert_invalid_combine_motif_configuration_preserves_output(
+        "multiple-motifs",
+        &[("CG", "0"), ("GATC", "1")],
+        "multiple motifs and combine-strands not currently supported",
+    );
 }
 
 #[test]

--- a/modkit/tests/test_pileup.rs
+++ b/modkit/tests/test_pileup.rs
@@ -131,6 +131,37 @@ fn run_cgcg0_combined_pileup(
     std::fs::read(output_path).unwrap()
 }
 
+fn run_negative_combine_anchor_pileup(
+    output_path: &Path,
+    motif_offset: &str,
+    optimized: bool,
+) -> std::process::Output {
+    let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_modkit"));
+    command.args([
+        "pileup",
+        "../tests/resources/CG_5mC_20230207_1700_6A_PAG66026_3c0abf27_oligo_741_adapters_modcalls_0th_sort_10_reads.bam",
+        output_path.to_str().unwrap(),
+        "--motif",
+        "CGCG",
+        motif_offset,
+        "--combine-strands",
+        "--no-filtering",
+        "--ref",
+        "../tests/resources/CGI_ladder_3.6kb_ref.fa",
+        "--region",
+        "oligo_741_adapters:22-62",
+        "--interval-size",
+        "40",
+        "--threads",
+        "1",
+        "--suppress-progress",
+    ]);
+    if optimized {
+        command.args(["--modified-bases", "C:m"]);
+    }
+    command.output().unwrap()
+}
+
 #[test]
 fn test_pileup_motif_boundaries_are_preload_and_interval_invariant() {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -193,6 +224,68 @@ fn test_cgcg0_combined_optimized_and_generic_are_interval_invariant() {
             2,
         );
         assert!(observed.is_empty(), "optimized={optimized}");
+    }
+}
+
+#[test]
+fn test_negative_combine_anchor_is_rejected_before_opening_output() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let sentinel = b"existing output must remain unchanged\n";
+
+    for motif_offset in ["2", "3"] {
+        for optimized in [false, true] {
+            let processor = if optimized { "optimized" } else { "generic" };
+            let output_path = temp_dir
+                .path()
+                .join(format!("cgcg{motif_offset}-{processor}.bed"));
+
+            let output = run_negative_combine_anchor_pileup(
+                &output_path,
+                motif_offset,
+                optimized,
+            );
+            let diagnostics = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                !output.status.success(),
+                "CGCG {motif_offset} unexpectedly succeeded with {processor}"
+            );
+            assert!(
+                diagnostics.contains(&format!(
+                    "cannot combine strands for motif 'CGCG {motif_offset}'"
+                )),
+                "unexpected {processor} diagnostics: {diagnostics}"
+            );
+            assert!(
+                diagnostics.contains(
+                    "the reverse anchor must not precede the forward anchor"
+                ),
+                "unexpected {processor} diagnostics: {diagnostics}"
+            );
+            assert!(
+                !output_path.exists(),
+                "invalid {processor} request created its output"
+            );
+
+            std::fs::write(&output_path, sentinel).unwrap();
+            let output = run_negative_combine_anchor_pileup(
+                &output_path,
+                motif_offset,
+                optimized,
+            );
+            assert!(
+                !output.status.success(),
+                "CGCG {motif_offset} unexpectedly succeeded with {processor}"
+            );
+            assert_eq!(
+                std::fs::read(&output_path).unwrap(),
+                sentinel,
+                "invalid {processor} request truncated its output"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
**Review status: Author-reviewed and ready for ONT review.**

Addresses #678 and the pileup motif-mask portion of #676.

## Summary

This PR consolidates the related pileup motif correctness fixes in one review unit:

- Motif discovery and ownership are invariant to interval chunking and FASTA preload mode.
- Combine-strand motif geometry is validated before output creation or truncation.
- Dense/repeated combined-motif scans have a bounded progression while retaining every valid overlapping pair.
- Requests exceeding the eight motifs representable by the existing `u8` membership mask fail clearly before output mutation.
- Automatically added single-base motifs are deduplicated by primary base, so multiple requested modification codes for one base do not duplicate rows or falsely consume mask capacity.

## Severity

**High — scientific completeness, reproducibility, and output integrity.**

Accepted commands could omit motif sites or change results solely with chunking/preload mode. More than eight matching motifs could be accepted while the ninth was silently unrepresentable. Invalid combine-strand geometry could be detected only after replacing an existing output file.

## Root causes and fixes

- Motif-hit ownership was tied to query chunks rather than a stable half-open genomic anchor interval. The lookup now fetches enough context for boundary-spanning motifs while assigning each anchor to exactly one owned interval.
- Combined-strand partner discovery repeatedly expanded local closures. It now uses bounded geometric/disjoint scans and retains overlapping anchors exactly once.
- Combine-strand geometry validation ran too late. Missing, multiple, non-palindromic, and negative-displacement configurations are rejected during preset determination, before the writer is constructed.
- Motif membership uses a `u8`, but parsed and automatically added motif counts were not checked. Capacity is now validated both before and after automatic motif insertion.
- The automatic-insertion loop previously used a fixed snapshot of represented primary bases. It now updates that set as it inserts, ensuring one added motif per missing primary base.

## Reproduction and expected behavior

| Case | Before | After |
|---|---|---|
| Motif spans a chunk/preload boundary | Site can be omitted or duplicated depending on execution mode | Anchor is emitted once in every tested mode |
| Invalid combine-strand geometry | Error can occur after output truncation | Error occurs before creating or changing output |
| Dense `CGCG` repeat | Repeated closure expansion | All 255 pairs / 510 anchors retained with bounded scan work |
| Nine matching motifs | Command succeeds but the matching ninth `CGCG` label is absent | Clear 8-versus-9 error before output mutation |
| Exactly eight matching motifs | Supported | Supported, with all eight distinct labels asserted |
| Seven C motifs plus two requested A modification codes | Adds `A 0` twice, duplicating affected output and consuming nine mask slots | Adds one `A 0` motif and remains within the eight-motif limit |

The ninth-motif case was reproduced with installed modkit 0.6.4 on the included oligo fixture: it exited successfully, produced 11 rows, and reported only the first eight motif labels even though the ninth `CGCG 0` motif occurs in the requested reference interval.

## Testing

Tested exact head: `ea331688225f262ca26bc6b844194b24da27885f` (tree `19e43d07ee95e116e601274794370ff142e0f8f2`).

- `cargo test --offline --locked -p mod_kit motif_capacity_accepts_eight_and_rejects_nine --lib -- --nocapture`: 1 passed, 0 failed.
- `cargo test --offline --locked -p modkit --test test_pileup -- --nocapture`: 23 passed, 10 ignored, 0 failed.
- `cargo test --offline --locked --workspace --all-targets --no-fail-fast -- --test-threads=1`: 195 passed, 14 ignored, 0 failed.
- The fixture matrix covers chunk sizes and preload modes, both strands, overlapping motifs, negative/zero/positive displacement, validation ordering, absent-output and sentinel preservation, dense-repeat count/work bounds, all eight supported labels, explicit/automatic ninth-motif rejection, and same-primary-base automatic-motif deduplication.
- Installed modkit 0.6.4 parent-red check: the matching ninth motif is silently absent. Final-head regressions reject the request before creating/truncating output.
- Automatic-motif parent/fixed comparison: installed 0.6.4 logs `adding single-base motif: 'A 0'` twice and produces 38 rows for seven C motifs plus `m6A`/`2OmeA`; the final head adds `A 0` once and produces 23 rows with the expected eight distinct motif labels.
- Changed-file `rustfmt --check` and `git diff --check upstream/master...HEAD`: passed. Whole-workspace formatting still reports unrelated pre-existing formatting differences in untouched files.
- Independent Rust, bioinformatics, and supervisor reviews were performed on the exact final head before this PR was marked ready.

The large direct-RNA slice was not used for this change because the included genomic FASTA/motif fixtures provide exact boundary, coordinate, label, and count oracles. The added capacity checks run only during one-time preset construction, outside the per-read hot loop.

## Output and compatibility

- Previously omitted or duplicated affected coordinates intentionally change.
- Unsupported ninth-motif requests now fail explicitly instead of returning incomplete output.
- CLI options and bedMethyl schema are unchanged; valid requests with up to eight motifs retain the existing interface.
- Documentation is updated to describe the interval and combine-strand behavior.

## Non-goals

- MM-group progression and MM-code state cardinality are handled in PR #709.
- Pileup record-state/count accounting is handled in PR #656.
- No thresholding, scheduler/I/O, generic MM policy, or GPU change is included.

## Reviewer guide

1. Review the half-open owned-interval/context logic and bounded scan helpers in `fasta.rs`.
2. Review preflight validation ordering in `pileup/subcommand.rs`, including the checks before and after automatic motif insertion.
3. Review the boundary, combine-strand, dense-repeat, and eight/nine-motif oracles in `test_pileup.rs`.

## Author checklist

- [x] The PR body contains the observed and expected behavior without requiring the linked issues.
- [x] Related motif changes are consolidated; unrelated MM-scanner and record-counting changes are excluded.
- [x] Parent-red and exact-final-head green evidence is recorded.
- [x] Focused, full-workspace, formatting, coordinate/count, and output-preservation checks are listed above.
- [x] The exact final head was independently reviewed before marking this PR ready.
