### PR TITLE
Reject ambiguous overlapping repair placements

### DIFF
--- a/modkit-core/src/repair_tags.rs
+++ b/modkit-core/src/repair_tags.rs
@@ -6,6 +6,7 @@ use clap::Args;
 use derive_new::new;
 use indicatif::{MultiProgress, ProgressBar};
 use log::{debug, error, info, warn};
+use memchr::memmem::Finder;
 use rayon::prelude::*;
 use rust_htslib::bam::record::{Aux, AuxArray};
 use rust_htslib::bam::{self, Read};
@@ -324,17 +325,14 @@ fn repair_record_pair(record_pair: RecordPair) -> anyhow::Result<bam::Record> {
     if donor_seq.len() < acceptor_seq.len() {
         bail!("donor sequence for {read_name} is longer than acceptor sequence")
     }
-    let matches = donor_seq.match_indices(&acceptor_seq);
-
-    let starts =
-        matches.into_iter().map(|(start, _)| start).collect::<Vec<usize>>();
-    if starts.len() > 1 {
-        bail!("multiple potential corrections found for {read_name}")
-    } else if starts.is_empty() {
+    let finder = Finder::new(acceptor_seq.as_bytes());
+    let Some(start) = finder.find(donor_seq.as_bytes()) else {
         bail!("acceptor sequence is not a substring of the donor sequence")
+    };
+    if finder.find(&donor_seq.as_bytes()[start + 1..]).is_some() {
+        bail!("multiple potential corrections found for {read_name}")
     } else {
         let acceptor_seq_len = acceptor_seq.len();
-        let start = *starts.get(0).unwrap();
         let end = start + acceptor_seq_len;
 
         let mm_style = modbase_info.mm_style;
@@ -390,5 +388,104 @@ fn repair_record_pair(record_pair: RecordPair) -> anyhow::Result<bam::Record> {
         repaired_record.push_aux(MN_TAG.as_bytes(), mn)?;
 
         Ok(repaired_record)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rust_htslib::bam::{self, record::Aux};
+
+    use super::{repair_record_pair, RecordPair};
+
+    fn make_record(name: &[u8], sequence: &str) -> bam::Record {
+        let mut record = bam::Record::new();
+        record.set(name, None, sequence.as_bytes(), &vec![255; sequence.len()]);
+        record
+    }
+
+    fn make_donor(name: &[u8], sequence: &str) -> bam::Record {
+        let mut record = make_record(name, sequence);
+        record.push_aux(b"MM", Aux::String("A+a.,0;")).unwrap();
+        record.push_aux(b"ML", Aux::ArrayU8((&[200u8][..]).into())).unwrap();
+        record
+    }
+
+    fn repair(donor: &str, acceptor: &str) -> anyhow::Result<bam::Record> {
+        repair_record_pair(RecordPair::new(
+            Arc::new(make_donor(b"read", donor)),
+            make_record(b"read", acceptor),
+        ))
+    }
+
+    fn repair_reverse(
+        donor_stored_sequence: &str,
+        acceptor_stored_sequence: &str,
+    ) -> anyhow::Result<bam::Record> {
+        let mut donor = make_donor(b"reverse", donor_stored_sequence);
+        donor.set_reverse();
+        let mut acceptor = make_record(b"reverse", acceptor_stored_sequence);
+        acceptor.set_reverse();
+        repair_record_pair(RecordPair::new(Arc::new(donor), acceptor))
+    }
+
+    #[test]
+    fn repair_rejects_overlapping_ambiguous_placements() {
+        let error = repair("ACACAC", "ACAC").unwrap_err();
+        assert!(
+            error.to_string().contains("multiple potential corrections"),
+            "unexpected error: {error:#}"
+        );
+
+        assert!(repair("ACACGGACAC", "ACAC")
+            .unwrap_err()
+            .to_string()
+            .contains("multiple potential corrections"));
+    }
+
+    #[test]
+    fn repair_preserves_unique_and_absent_placement_behavior() {
+        let repaired = repair("TACACG", "ACAC").unwrap();
+        assert!(matches!(repaired.aux(b"MM").unwrap(), Aux::String("A+a.,0;")));
+        match repaired.aux(b"ML").unwrap() {
+            Aux::ArrayU8(qualities) => {
+                assert_eq!(qualities.iter().collect::<Vec<_>>(), vec![200]);
+            }
+            other => panic!("unexpected ML tag: {other:?}"),
+        }
+        assert!(matches!(repaired.aux(b"MN").unwrap(), Aux::U32(4)));
+
+        assert!(repair("ACACAC", "CGCG")
+            .unwrap_err()
+            .to_string()
+            .contains("not a substring"));
+    }
+
+    #[test]
+    fn repair_searches_forward_sequences_for_reverse_records() {
+        // Stored placement starts at 3, while the forward-sequence placement
+        // TACGAAA -> ACG starts at 1.
+        let repaired = repair_reverse("TTTCGTA", "CGT").unwrap();
+        assert!(repaired.is_reverse());
+        assert!(matches!(repaired.aux(b"MM").unwrap(), Aux::String("A+a.,0;")));
+        match repaired.aux(b"ML").unwrap() {
+            Aux::ArrayU8(qualities) => {
+                assert_eq!(qualities.iter().collect::<Vec<_>>(), vec![200]);
+            }
+            other => panic!("unexpected ML tag: {other:?}"),
+        }
+        assert!(matches!(repaired.aux(b"MN").unwrap(), Aux::U32(3)));
+
+        assert!(repair_reverse("GTGTGT", "GTGT")
+            .unwrap_err()
+            .to_string()
+            .contains("multiple potential corrections"));
+    }
+
+    #[test]
+    fn repair_returns_errors_for_empty_sequences() {
+        assert!(repair("ACAC", "").is_err());
+        assert!(repair("", "ACAC").is_err());
     }
 }


### PR DESCRIPTION
<!-- Suggested title: Reject ambiguous overlapping repair placements -->

Fixes #679.

## Summary

- Detects overlapping as well as non-overlapping occurrences of an acceptor sequence within its donor sequence.
- Rejects an ambiguous repair record instead of silently projecting MM/ML calls from an arbitrary placement.
- Adds forward, reverse, repeated, unique, absent, and one-sided empty-sequence controls.

## Severity

**Severity:** Medium — scientific correctness

**Rationale:** For repetitive donor sequence, the current command can report successful repair and emit plausible MM/ML tags using the first of multiple biologically inequivalent placements. This can silently move modification probabilities to incorrect acceptor positions. Exposure is data-dependent and record-local.

## Root cause

`str::match_indices` reports non-overlapping occurrences. For donor `ACACAC` and acceptor `ACAC`, it reports the occurrence at offset 0 but skips the overlapping occurrence at offset 2, so the code incorrectly treats the placement as unique.

## Implementation

The repair path uses the existing direct `memchr` dependency:

1. Find the first occurrence with `memmem::Finder`.
2. Search again from one byte after the first start.
3. Reject the record if any second occurrence exists, including an overlapping occurrence.

This uses two bounded linear, allocation-free searches and leaves the existing unique-placement projection unchanged.

### Preserved behavior

- Unique forward and reverse placements retain the same MM/ML/MN projection.
- Absent placements, one-sided empty sequences, and separate non-overlapping repeats remain bounded per-record rejections.
- Per-record repair failures remain nonfatal to the command.

### Non-goals

- No heuristic or alignment-based choice among ambiguous placements.
- No query-name merge, worker ordering, fatal I/O, or atomic-output change; those are addressed separately by #680.
- No duplicate-flagged donor policy change.

## Behavior before and after

| Case | Before | After | Expected oracle |
|---|---|---|---|
| Donor `ACACAC`, acceptor `ACAC` | Reports one repaired record and chooses offset 0 | Rejects the ambiguous record | Occurrences at offsets 0 and 2 imply no unique projection |
| Separate non-overlapping repeated occurrences | Rejected | Rejected | Existing ambiguity behavior preserved |
| Unique donor `TACACG`, acceptor `ACAC` | Emits repaired MM/ML/MN tags | Same tags | `MM:Z:A+a.,0;`, `ML:B:C,200`, `MN:i:4` |
| Reverse-strand unique and overlapping controls | Unique case repaired; overlapping case could be missed | Unique case unchanged; overlapping case rejected | Forward-sequence placement semantics preserved |

## Testing

**Test environment**

- Revision tested: `2c4a880c7087302eed279f7ddca441e4d31253a8`
- Tree tested and worktree state: `9085e47e35517571724ae11ff1d2bd090b342fbf`; clean after testing
- Toolchain: rustc/cargo 1.90.0
- Platform: macOS 26.6, arm64 Apple Silicon
- Reference binary: installed modkit 0.6.4
- External tools: samtools 1.23.1 for the public inline SAM/BAM reproduction
- Dependency resolution identity: ignored worktree `Cargo.lock` SHA-256 `49c08c4c51b6f4320726551146d971fa9ef2183d40c3f6c631b2005965e242c0`; `memchr` 2.8.3, `rust-htslib` 0.46.0, `hts-sys` 2.2.0

| Test layer | Exact command, fixture, or matrix | Result and evidence |
|---|---|---|
| **Core: parent-red regression** | Exact parent `5cecc3fb3a9336068d9e3c68d5c08d678153dd2c`; replay the focused forward/reverse overlapping fixtures | Parent accepts the forward `ACACAC`/`ACAC` placement and the equivalent reverse overlap instead of rejecting them |
| **Core: focused regression** | `TMPDIR=/private/tmp/modkit-u58-test-tmp cargo test -p mod_kit repair_tags::tests -- --nocapture --test-threads=1` | 4 passed, 0 failed; overlap/non-overlap, unique/absent, reverse, and empty controls passed |
| **Core: affected CLI/integration tests** | `test_repair` target within the isolated workspace gate | 3 passed, 0 failed; public repair regression, MN tag, and help behavior remain green |
| **Core: applicable full workspace gate** | `TMPDIR=/private/tmp/modkit-u58-test-tmp cargo test --workspace --all-targets --no-fail-fast -- --test-threads=1` | 183 passed, 14 ignored, 0 failed |
| Installed-versus-fixed comparison | Inline donor/acceptor fixture from issue #679 | Installed 0.6.4 emits one repaired `repeat` record; fixed code emits zero repaired and one failed record and continues normally |
| Boundary probe | Query-name-sorted donor and acceptor SAM records with `*` sequences on exact head | Normal per-record rejection with `empty-read-sequence`; no `Finder` access or panic, confirming empty sequences are rejected before substring search |
| **Core: formatting/diff checks** | `rustfmt --edition 2021 --check modkit-core/src/repair_tags.rs`; `git diff --check upstream/master...HEAD` | Both passed; clean one-file diff, 105 insertions and 8 deletions |

### Tests not performed

- No large real-data or performance benchmark was run. The change has no performance claim; it replaces collection of non-overlapping matches with at most two linear substring searches.
- No alignment-based disambiguation was tested because selecting among ambiguous placements is explicitly out of scope.

## Scientific validation

- Population/eligibility invariant: only records without a unique sequence placement change category, from repaired to existing nonfatal per-record rejection.
- Count/category conservation invariant: the minimal ambiguous fixture changes exactly from one repaired/zero failed to zero repaired/one failed; unrelated records continue.
- Coordinate/strand/interval invariant: a repair is emitted only when the donor-to-acceptor offset is unique in forward-sequence coordinates; reverse-strand controls use the same oracle.
- Determinism invariant: every ambiguous record is rejected rather than selecting an occurrence based on search order.
- Independent oracle or specialist review: occurrence starts 0 and 2 are directly enumerable; Rust and scientific reviews approved the frozen one-file branch.

## Output and compatibility

- User-visible change: affected repetitive reads are logged/counted as failed repair records instead of receiving arbitrary projected tags.
- Expected output differences: ambiguous records disappear from the repaired BAM; unique records are unchanged.
- Byte-identical controls: focused unique-placement MM/ML/MN values are exact; existing repair integration tests remain green.
- CLI/API/schema compatibility: no option, public API, header, or tag schema change.
- Partial-output or failure semantics: ambiguity remains a nonfatal record-level rejection.

## Reviewer guide

1. Review the parent `match_indices` behavior on `ACACAC`/`ACAC`.
2. Review the two `Finder` calls in `repair_record_pair`.
3. Review the reverse and unique-placement controls for unchanged MM/ML/MN behavior.
4. Rerun: `cargo test -p mod_kit repair_tags::tests -- --nocapture --test-threads=1`.
5. Prefer merging this PR before #680; then rebase #680 so the separate ordering/lifecycle work retains this small scientific correction.

## Checklist

- [x] The issue contains reproducible observed and expected behavior.
- [x] The change is limited to the linked issue's approved scope.
- [x] The regression is demonstrably red on the exact parent revision.
- [x] All tests actually performed are listed above with their results.
- [x] Unrun or inapplicable tests are disclosed.
- [x] Scientific counts/statistics and output compatibility are explicitly checked.
- [x] Formatting and diff-hygiene checks pass, or unrelated findings are documented.
- [x] No generated data, private sample identifiers, or unrelated changes are included.
