### PR TITLE
Correct entropy regional medians and singleton summaries

### DIFF
--- a/modkit-core/src/entropy/mod.rs
+++ b/modkit-core/src/entropy/mod.rs
@@ -1677,6 +1677,7 @@ impl BedRegion {
 #[cfg(test)]
 mod entropy_mod_tests {
     use crate::entropy::{BedRegion, DescriptiveStats};
+    use itertools::Itertools;
 
     #[test]
     fn singleton_entropy_summary_uses_its_value_as_the_median() {
@@ -1760,6 +1761,32 @@ mod entropy_mod_tests {
 
         assert_eq!(observed.median_entropy, sorted.median_entropy);
         assert_eq!(observed.median_entropy, 0.4);
+    }
+
+    #[test]
+    fn regional_medians_are_stable_across_all_small_encounter_orders() {
+        for (values, expected_median) in [
+            (vec![0.75, 0.25, 0.5], 0.5),
+            (vec![0.75, 0.0, 0.25, 0.5], 0.375),
+        ] {
+            for measurements in
+                values.iter().copied().permutations(values.len())
+            {
+                let original_order = measurements.clone();
+                let reads = vec![1; measurements.len()];
+                let stats = DescriptiveStats::new(
+                    &measurements,
+                    &reads,
+                    0,
+                    0,
+                    &(10..20),
+                )
+                .unwrap();
+
+                assert_eq!(stats.median_entropy, expected_median);
+                assert_eq!(measurements, original_order);
+            }
+        }
     }
 
     #[test]

--- a/modkit-core/src/entropy/mod.rs
+++ b/modkit-core/src/entropy/mod.rs
@@ -1671,7 +1671,91 @@ impl BedRegion {
 
 #[cfg(test)]
 mod entropy_mod_tests {
-    use crate::entropy::BedRegion;
+    use crate::entropy::{BedRegion, DescriptiveStats};
+
+    #[test]
+    fn singleton_entropy_summary_uses_its_value_as_the_median() {
+        let stats = DescriptiveStats::new(&[0.25], &[7], 2, 0, &(10..11))
+            .expect("a singleton is a valid regional entropy summary");
+
+        assert_eq!(stats.mean_entropy, 0.25);
+        assert_eq!(stats.median_entropy, 0.25);
+        assert_eq!(stats.min_entropy, 0.25);
+        assert_eq!(stats.max_entropy, 0.25);
+        assert_eq!(stats.mean_num_reads, 7.0);
+        assert_eq!(stats.min_num_reads, 7);
+        assert_eq!(stats.max_num_reads, 7);
+        assert_eq!(stats.successful_count, 1);
+        assert_eq!(stats.failed_count, 2);
+    }
+
+    #[test]
+    fn multi_window_entropy_summary_keeps_existing_exact_statistics() {
+        let stats = DescriptiveStats::new(
+            &[0.25, 0.5, 0.75],
+            &[2, 4, 6],
+            1,
+            0,
+            &(10..20),
+        )
+        .unwrap();
+
+        assert_eq!(stats.mean_entropy, 0.5);
+        assert_eq!(stats.median_entropy, 0.5);
+        assert_eq!(stats.min_entropy, 0.25);
+        assert_eq!(stats.max_entropy, 0.75);
+        assert_eq!(stats.mean_num_reads, 4.0);
+        assert_eq!(stats.min_num_reads, 2);
+        assert_eq!(stats.max_num_reads, 6);
+        assert_eq!(stats.successful_count, 3);
+        assert_eq!(stats.failed_count, 1);
+    }
+
+    #[test]
+    fn region_median_is_independent_of_window_encounter_order() {
+        let observed = DescriptiveStats::new(
+            &[0.9, 0.1, 0.4, 0.2],
+            &[9, 1, 4, 2],
+            0,
+            0,
+            &(10..20),
+        )
+        .unwrap();
+        let sorted = DescriptiveStats::new(
+            &[0.1, 0.2, 0.4, 0.9],
+            &[1, 2, 4, 9],
+            0,
+            0,
+            &(10..20),
+        )
+        .unwrap();
+
+        assert_eq!(observed.median_entropy, sorted.median_entropy);
+        assert_eq!(observed.median_entropy, 0.3);
+    }
+
+    #[test]
+    fn odd_region_median_is_independent_of_window_encounter_order() {
+        let observed = DescriptiveStats::new(
+            &[0.9, 0.1, 0.4],
+            &[9, 1, 4],
+            0,
+            0,
+            &(10..20),
+        )
+        .unwrap();
+        let sorted = DescriptiveStats::new(
+            &[0.1, 0.4, 0.9],
+            &[1, 4, 9],
+            0,
+            0,
+            &(10..20),
+        )
+        .unwrap();
+
+        assert_eq!(observed.median_entropy, sorted.median_entropy);
+        assert_eq!(observed.median_entropy, 0.4);
+    }
 
     #[test]
     fn test_bed_region_parsing() {

--- a/modkit-core/src/entropy/mod.rs
+++ b/modkit-core/src/entropy/mod.rs
@@ -1386,8 +1386,13 @@ impl DescriptiveStats {
                 "measurements and n_reads should be the same length"
             );
             let mean_entropy = Self::mean(measurements);
-            let median_entropy =
-                percentile_linear_interp(measurements, 0.5f32)?;
+            let median_entropy = if measurements.len() == 1 {
+                measurements[0]
+            } else {
+                let mut sorted_measurements = measurements.to_vec();
+                sorted_measurements.sort_unstable_by(f32::total_cmp);
+                percentile_linear_interp(&sorted_measurements, 0.5f32)?
+            };
             // safe because of above check
             let (min_entropy, max_entropy) = match measurements.iter().minmax()
             {

--- a/modkit/tests/test_entropy_region_statistics.rs
+++ b/modkit/tests/test_entropy_region_statistics.rs
@@ -1,0 +1,106 @@
+use rust_htslib::bam::{
+    self,
+    header::HeaderRecord,
+    record::{Aux, Cigar, CigarString},
+};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn write_reference(root: &Path) -> PathBuf {
+    let reference = root.join("reference.fa");
+    fs::write(&reference, ">chr1\nAACGAA\n").unwrap();
+    fs::write(root.join("reference.fa.fai"), "chr1\t6\t6\t6\t7\n").unwrap();
+    reference
+}
+
+fn write_bam(root: &Path) -> PathBuf {
+    let bam_path = root.join("reads.bam");
+    let mut header = bam::Header::new();
+    let mut sq = HeaderRecord::new(b"SQ");
+    sq.push_tag(b"SN", "chr1").push_tag(b"LN", 6);
+    header.push_record(&sq);
+
+    let cigar = CigarString(vec![Cigar::Match(6)]);
+    let mut record = bam::Record::new();
+    record.set(b"read-0", Some(&cigar), b"AACGAA", &[30; 6]);
+    record.set_tid(0);
+    record.set_pos(0);
+    record.set_mapq(60);
+    record.push_aux(b"MM", Aux::String("C+m?,0;")).unwrap();
+    record.push_aux(b"ML", Aux::ArrayU8((&[255][..]).into())).unwrap();
+    record.push_aux(b"MN", Aux::U32(6)).unwrap();
+    record.push_aux(b"NM", Aux::U32(0)).unwrap();
+
+    let mut writer =
+        bam::Writer::from_path(&bam_path, &header, bam::Format::Bam).unwrap();
+    writer.write(&record).unwrap();
+    drop(writer);
+    bam::index::build(&bam_path, None, bam::index::Type::Bai, 1).unwrap();
+    bam_path
+}
+
+#[test]
+fn singleton_region_emits_exact_summary_statistics() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let reference = write_reference(temp_dir.path());
+    let bam = write_bam(temp_dir.path());
+    let regions = temp_dir.path().join("regions.bed");
+    fs::write(&regions, "chr1\t2\t3\tsingleton\n").unwrap();
+    let output_dir = temp_dir.path().join("output");
+
+    let result = Command::new(env!("CARGO_BIN_EXE_modkit"))
+        .args([
+            "entropy",
+            "--in-bam",
+            bam.to_str().unwrap(),
+            "--out-bed",
+            output_dir.to_str().unwrap(),
+            "--ref",
+            reference.to_str().unwrap(),
+            "--base",
+            "C",
+            "--num-positions",
+            "1",
+            "--window-size",
+            "1",
+            "--min-coverage",
+            "1",
+            "--max-filtered-positions",
+            "0",
+            "--filter-threshold",
+            "0",
+            "--threads",
+            "1",
+            "--io-threads",
+            "1",
+            "--regions",
+            regions.to_str().unwrap(),
+            "--prefix",
+            "singleton",
+            "--suppress-progress",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        result.status.success(),
+        "{}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let windows = fs::read_to_string(
+        output_dir.join("singleton_windows.bedgraph"),
+    )
+    .unwrap();
+    let window_fields = windows.trim_end().split('\t').collect::<Vec<_>>();
+    // Motif/window interval normalization belongs to issue #681. This test
+    // isolates the regional summary and only requires one successful window
+    // with the expected biological value and coverage.
+    assert_eq!(window_fields[0], "chr1");
+    assert_eq!(window_fields[1], "2");
+    assert_eq!(&window_fields[3..], &["0", "+", "1"]);
+    assert_eq!(
+        fs::read(output_dir.join("singleton_regions.bed")).unwrap(),
+        b"chr1\t2\t3\tsingleton\t0\t+\t0\t0\t0\t1\t1\t1\t1\t0\n"
+    );
+}


### PR DESCRIPTION
<!-- Suggested title: Correct entropy regional medians and singleton summaries -->

Fixes #682.

## Summary

- Emits a valid regional entropy summary when exactly one window succeeds.
- Sorts a private copy of multi-window entropy values before median interpolation.
- Adds exact singleton CLI and exhaustive odd/even permutation regressions while preserving encounter order in the caller.

## Severity

**Severity:** High — scientific and statistical accuracy

**Rationale:** `entropy --regions` can exit successfully while omitting a valid singleton region or reporting a plausible but incorrect median for ordinary unsorted genomic-order values. The output itself does not reveal the statistical error.

## Root cause

Entropy-local `DescriptiveStats::new` passed every nonempty measurement slice directly to the shared percentile helper. That helper intentionally requires at least two observations and assumes its input is already sorted. Regional entropy values arrive in genomic encounter order, not numeric order.

## Implementation

- For one measurement, use that value directly as the median.
- For two or more measurements, copy and sort the values with `f32::total_cmp`, then call the unchanged linear-interpolation helper.
- Continue calculating mean, minimum, maximum, read counts, and success/failure counts from the original inputs.

The production change is seven entropy-local lines. Tests-first, production, and expanded CLI/permutation coverage remain separate commits.

### Preserved behavior

- The shared percentile helper and automatic-threshold behavior are unchanged.
- Mean/min/max, read-count statistics, and successful/failed window counts are unchanged.
- The caller's genomic-order measurement slice is not mutated.
- The existing interpolation convention for even sample sizes is retained.

### Non-goals

- No change to entropy window coordinates, motif ownership, filtering, thresholds, entropy normalization, floating-point reduction order, or output schema.
- No coverage weighting or redefinition of the regional aggregation unit.
- No change to #681/#683 geometry, ownership, or state-cardinality handling.

## Behavior before and after

| Case | Before | After | Expected oracle |
|---|---|---|---|
| One successful window | Shared helper rejects one datapoint; region row is omitted | Emits one regional row | mean/median/min/max equal the lone value; exact read and success/failure counts |
| Values `[0.75, 0.25, 0.50]` in genomic order | Median 0.25 | Median 0.50 | Median of value-sorted `[0.25, 0.50, 0.75]` |
| Values `[0.75, 0.00, 0.25, 0.50]` | Median 0.125 | Median 0.375 | Existing interpolation over sorted middle values 0.25 and 0.50 |
| Permutations of the same multiset | Can report different medians | Report the same median | All 6 odd and 24 even permutations agree; caller input remains unmodified |

## Testing

**Test environment**

- Revision tested: `7e5050c13ac13a3c6614f532485c45145f253228`
- Tree tested and worktree state: `556d905849c1a3544440a1f70bd11e04f973a3cb`; clean after testing
- Toolchain: rustc/cargo 1.90.0
- Platform: macOS 26.6, arm64 Apple Silicon
- Reference binary: installed modkit 0.6.4 and exact upstream parent `5cecc3fb3a9336068d9e3c68d5c08d678153dd2c`
- External tools: samtools 1.23.1 for the public CLI fixture
- Dependency resolution identity: ignored `Cargo.lock` SHA-256 `f9d3389f8fc63c9ad653dad3fbf43a1c26cc54008f0a39e06e71ff6455a1e9b5`; `rust-htslib` 0.46.0, `hts-sys` 2.2.0

| Test layer | Exact command, fixture, or matrix | Result and evidence |
|---|---|---|
| **Core: parent-red regression** | Exact parent and installed 0.6.4; replay singleton and odd/even median oracles | Singleton unit returns `PercentileNotEnoughDatapoints(1)` and installed CLI leaves the region file empty; unsorted odd/even inputs report 0.25/0.125 instead of 0.50/0.375 |
| **Core: focused regression** | `cargo test -p mod_kit entropy::entropy_mod_tests --lib -- --test-threads=1` | 6 passed, 0 failed; singleton exact fields plus all 6 odd and 24 even permutations pass without input mutation |
| **Core: affected CLI integration** | `cargo test -p modkit --test test_entropy_region_statistics -- --test-threads=1` | 1 passed, 0 failed; exact singleton regional row SHA-256 `a58b12803513e46fe62df518c33db75fd7471dcb9fc7482ec3a69cf1aaabc9c3` |
| Existing entropy integration | `cargo test -p modkit --test test_entropy -- --test-threads=1` | 2 passed, 0 failed |
| **Core: applicable full workspace gate** | `TMPDIR=/private/tmp/modkit-tmp-entropy-regional-statistics cargo test --workspace --all-targets -- --test-threads=1` | 185 passed, 14 ignored, 0 failed on the exact final head |
| **Core: formatting/diff checks** | Targeted stable `rustfmt --check`; `git diff --check upstream/master...HEAD` | Changed patch passes. Whole-workspace stable formatting is not a clean upstream gate because `.rustfmt.toml` requests nightly-only options and untouched files also differ |

### Tests not performed

- No large-data performance, memory, or I/O benchmark was run. The production work is one singleton branch and one short private sort per regional summary, with no performance claim.
- No change or test of the separate final-bit entropy reduction reproducibility question was made.

## Scientific validation

- Population/eligibility invariant: every region with at least one successful measurement remains eligible; no window population is added or removed.
- Count/category conservation invariant: singleton and multi-window read counts plus success/failure fields are exact and unchanged.
- Coordinate/strand/interval invariant: genomic window order and region coordinates are not mutated; only a private value copy is sorted.
- Determinism invariant: median is invariant across every tested permutation of the same odd/even values.
- Independent oracle or specialist review: singleton statistics and the two median order statistics are directly enumerable; Bioinformatics and supervisor source reviews approved the frozen branch.

## Output and compatibility

- User-visible change: singleton region rows are emitted, and previously incorrect unsorted medians are corrected.
- Expected output differences: only omitted singleton summaries and incorrect median fields change.
- Byte-identical controls: existing entropy integration remains green; non-median statistics are asserted unchanged.
- CLI/API/schema compatibility: no option, Rust API, column, or schema change.
- Partial-output or failure semantics: a valid singleton is no longer downgraded to a failed regional statistic.

## Reviewer guide

1. Review the two parent assumptions documented in issue #682 and the seven-line `DescriptiveStats::new` change.
2. Confirm sorting occurs on a private copy and uses `f32::total_cmp`.
3. Review the singleton CLI row and exhaustive odd/even permutation test.
4. Rerun `cargo test -p mod_kit entropy::entropy_mod_tests --lib` and `cargo test -p modkit --test test_entropy_region_statistics`.
5. Confirm the shared percentile helper and all non-median statistics remain unchanged.

## Checklist

- [x] The issue contains reproducible observed and expected behavior.
- [x] The change is limited to the linked issue's approved scope.
- [x] The regressions are demonstrably red on the exact parent/released binary.
- [x] All tests actually performed are listed above with their results.
- [x] Unrun or inapplicable tests are disclosed.
- [x] Scientific counts/statistics and output compatibility are explicitly checked.
- [x] Formatting and diff-hygiene checks pass, or unrelated findings are documented.
- [x] No generated data, private sample identifiers, or unrelated changes are included.
