### PR TITLE
Preserve pileup calls around ambiguous query bases

### DIFF
--- a/modkit-core/src/pileup/base_mods_adapter.rs
+++ b/modkit-core/src/pileup/base_mods_adapter.rs
@@ -77,7 +77,7 @@ impl<'a, const SIZE: usize> BaseModsAdapter<'a, SIZE> {
                         b'C' | b'c' => agg[2] += 1u32,
                         b'G' | b'g' => agg[1] += 1u32,
                         b'T' | b't' => agg[0] += 1u32,
-                        _ => unreachable!(),
+                        _ => {}
                     }
                     agg
                 },
@@ -465,11 +465,23 @@ fn parse_int<const DELIM: u8, const END: u8>(bs: &[u8]) -> (u32, usize) {
 
 fn base_complement(base: u8) -> u8 {
     match base {
+        b'=' => b'=',
         b'A' => b'T',
         b'C' => b'G',
+        b'M' => b'K',
         b'G' => b'C',
+        b'R' => b'Y',
+        b'S' => b'S',
+        b'V' => b'B',
         b'T' => b'A',
-        _ => panic!("not allowed base"),
+        b'W' => b'W',
+        b'Y' => b'R',
+        b'H' => b'D',
+        b'K' => b'M',
+        b'D' => b'H',
+        b'B' => b'V',
+        b'N' => b'N',
+        _ => base,
     }
 }
 
@@ -620,6 +632,33 @@ mod base_mods_adapter_tests {
         assert_eq!(mod_state.mod_code, ModCodeRepr::Code('h'));
         let mod_state = scanner.next_modified_position([0f32; 4], &[]).unwrap();
         assert!(mod_state.is_none());
+    }
+
+    #[test]
+    fn test_ambiguous_query_bases_preserve_mm_scanning() {
+        for (seq, reverse, expected) in [
+            ("CARNCC", false, vec![(0, 235), (4, 225)]),
+            ("GNYGG", true, vec![(3, 225), (4, 235)]),
+        ] {
+            let record =
+                make_record("C+m?,0,0;", &[20, 30], seq, None, reverse);
+            let mut scanner = BaseModsAdapter::<1>::new(&record).unwrap();
+            let states = std::iter::from_fn(|| {
+                scanner.next_modified_position([0f32; 4], &[]).unwrap()
+            })
+            .map(|state| {
+                assert_eq!(
+                    state.primary_base,
+                    crate::mod_base_code::DnaBase::C
+                );
+                assert!(!state.modified);
+                assert!(!state.inferred);
+                (state.mod_position, state.mod_qual)
+            })
+            .collect::<Vec<_>>();
+
+            assert_eq!(states, expected, "reverse={reverse}");
+        }
     }
 
     #[test]

--- a/modkit-core/src/pileup/mod.rs
+++ b/modkit-core/src/pileup/mod.rs
@@ -171,6 +171,7 @@ pub struct ModBasePileup2 {
     pub(crate) interval_width: usize,
     pub(crate) stride: usize,
     pub(crate) failed_records: usize,
+    pub(crate) reference_equal_records: usize,
     pub(crate) phased_feature_counts: [Vec<PileupFeatureCounts2>; 2],
 }
 
@@ -182,6 +183,7 @@ impl ModBasePileup2 {
             interval_width: 0,
             stride: 0,
             failed_records: 0,
+            reference_equal_records: 0,
             phased_feature_counts: [Vec::new(), Vec::new()],
         }
     }

--- a/modkit-core/src/pileup/pileup_processor.rs
+++ b/modkit-core/src/pileup/pileup_processor.rs
@@ -51,6 +51,17 @@ where
     ) -> anyhow::Result<ModBasePileup2>;
 }
 
+#[inline]
+fn get_query_base(record: &bam::Record, qpos: usize) -> Option<DnaBase> {
+    DnaBase::try_from(record.seq()[qpos]).ok().map(|base| {
+        if record.is_reverse() {
+            base.complement()
+        } else {
+            base
+        }
+    })
+}
+
 pub(super) struct DnaPileupWorker<
     T,
     M,
@@ -319,17 +330,8 @@ impl<
                     // at this aligned position, but there is no modification
                     // call
                     (Some(q), Some(mp)) if q < mp.mod_position => {
-                        let base = {
-                            let Ok(tmp) = DnaBase::try_from(record.seq()[q])
-                            else {
-                                erred_records = erred_records.saturating_add(1);
-                                continue 'records;
-                            };
-                            if record.is_reverse() {
-                                tmp.complement()
-                            } else {
-                                tmp
-                            }
+                        let Some(base) = get_query_base(&record, q) else {
+                            continue 'pileup;
                         };
                         self.matrix
                             .incr_diff_call(rpos, base, ref_base, reverse, hp);
@@ -362,22 +364,16 @@ impl<
                                             break 'overran;
                                         } else {
                                             assert!(pos > q);
-                                            let base = {
-                                                let tmp = DnaBase::try_from(
-                                                    record.seq()[q],
-                                                )
-                                                .unwrap();
-                                                if record.is_reverse() {
-                                                    tmp.complement()
-                                                } else {
-                                                    tmp
-                                                }
+                                            mod_state = Some(ms);
+                                            let Some(base) =
+                                                get_query_base(&record, q)
+                                            else {
+                                                break 'overran;
                                             };
                                             self.matrix.incr_diff_call(
                                                 rpos, base, ref_base, reverse,
                                                 hp,
                                             );
-                                            mod_state = Some(ms);
                                             break 'overran;
                                         }
                                     }
@@ -388,20 +384,14 @@ impl<
                                     continue 'records;
                                 }
                                 Ok(None) => {
-                                    let base = {
-                                        let tmp =
-                                            DnaBase::try_from(record.seq()[q])
-                                                .unwrap();
-                                        if record.is_reverse() {
-                                            tmp.complement()
-                                        } else {
-                                            tmp
-                                        }
+                                    mod_state = None;
+                                    let Some(base) = get_query_base(&record, q)
+                                    else {
+                                        break 'overran;
                                     };
                                     self.matrix.incr_diff_call(
                                         rpos, base, ref_base, reverse, hp,
                                     );
-                                    mod_state = None;
                                     break 'overran;
                                 }
                             }
@@ -412,14 +402,8 @@ impl<
                         self.matrix.incr_delete(rpos, reverse, hp);
                     }
                     (Some(q), None) => {
-                        let base = {
-                            let tmp =
-                                DnaBase::try_from(record.seq()[q]).unwrap();
-                            if record.is_reverse() {
-                                tmp.complement()
-                            } else {
-                                tmp
-                            }
+                        let Some(base) = get_query_base(&record, q) else {
+                            continue 'pileup;
                         };
                         self.matrix
                             .incr_diff_call(rpos, base, ref_base, reverse, hp);
@@ -755,17 +739,8 @@ impl PileupWorker for GenericPileupWorker {
                         continue 'pileup;
                     }
                     (Some(q), Some(mp)) if q < mp => {
-                        let base = {
-                            let Ok(tmp) = DnaBase::try_from(record.seq()[q])
-                            else {
-                                erred_records = erred_records.saturating_add(1);
-                                continue 'records;
-                            };
-                            if record.is_reverse() {
-                                tmp.complement()
-                            } else {
-                                tmp
-                            }
+                        let Some(base) = get_query_base(&record, q) else {
+                            continue 'pileup;
                         };
                         if implicit_bases.contains(&base) {
                             add_to_tally(
@@ -860,15 +835,13 @@ impl PileupWorker for GenericPileupWorker {
                                     break 'overran;
                                 } else {
                                     assert!(pos > q);
-                                    let base = {
-                                        let tmp =
-                                            DnaBase::try_from(record.seq()[q])
-                                                .unwrap();
-                                        if record.is_reverse() {
-                                            tmp.complement()
-                                        } else {
-                                            tmp
-                                        }
+                                    mod_pos = Some(pos);
+                                    canonical_base = Some(can_base);
+                                    pos_base_mod_call = Some(call);
+                                    mod_strand = Some(pos_mod_strand);
+                                    let Some(base) = get_query_base(&record, q)
+                                    else {
+                                        break 'overran;
                                     };
                                     if implicit_bases.contains(&base) {
                                         add_to_tally(
@@ -891,10 +864,6 @@ impl PileupWorker for GenericPileupWorker {
                                             motif_idxs,
                                         );
                                     }
-                                    mod_pos = Some(pos);
-                                    canonical_base = Some(can_base);
-                                    pos_base_mod_call = Some(call);
-                                    mod_strand = Some(pos_mod_strand);
                                     break 'overran;
                                 }
                             }
@@ -910,14 +879,8 @@ impl PileupWorker for GenericPileupWorker {
                         );
                     }
                     (Some(q), None) => {
-                        let base = {
-                            let tmp =
-                                DnaBase::try_from(record.seq()[q]).unwrap();
-                            if record.is_reverse() {
-                                tmp.complement()
-                            } else {
-                                tmp
-                            }
+                        let Some(base) = get_query_base(&record, q) else {
+                            continue 'pileup;
                         };
                         if implicit_bases.contains(&base) {
                             add_to_tally(

--- a/modkit-core/src/pileup/pileup_processor.rs
+++ b/modkit-core/src/pileup/pileup_processor.rs
@@ -62,6 +62,37 @@ fn get_query_base(record: &bam::Record, qpos: usize) -> Option<DnaBase> {
     })
 }
 
+#[inline]
+fn record_uses_reference_equal_bases(record: &bam::Record) -> bool {
+    let seq = record.seq();
+    // Each complete byte stores two bases. For odd-length sequences, only
+    // inspect the final high nibble because the low nibble is zero padding.
+    let complete_bytes = seq.len() / 2;
+    seq.encoded[..complete_bytes]
+        .iter()
+        .any(|packed| packed & 0x0f == 0 || packed >> 4 == 0)
+        || (seq.len() % 2 == 1 && seq.encoded[complete_bytes] >> 4 == 0)
+}
+
+#[cfg(test)]
+mod reference_equal_base_tests {
+    use super::*;
+
+    #[test]
+    fn odd_length_padding_is_not_a_reference_equal_base() {
+        let mut canonical = bam::Record::new();
+        canonical.set(b"canonical", None, b"ACGTA", &[30; 5]);
+        let seq = canonical.seq();
+        assert_eq!(seq.len(), 5);
+        assert_eq!(seq.encoded.last().unwrap() & 0x0f, 0);
+        assert!(!record_uses_reference_equal_bases(&canonical));
+
+        let mut reference_equal = bam::Record::new();
+        reference_equal.set(b"reference-equal", None, b"AC=TA", &[30; 5]);
+        assert!(record_uses_reference_equal_bases(&reference_equal));
+    }
+}
+
 pub(super) struct DnaPileupWorker<
     T,
     M,
@@ -157,6 +188,7 @@ impl<
         mut pileup_space: ModBasePileup2,
     ) -> anyhow::Result<ModBasePileup2> {
         let mut erred_records = 0usize;
+        let mut reference_equal_records = 0usize;
         let chrom_tid = item.chrom_tid;
         let start_pos = item.start_pos;
         let end_pos = item.end_pos;
@@ -203,6 +235,16 @@ impl<
             });
 
         'records: for (record, hp) in records {
+            // BAM code zero (`=` in SAM) means "same as the reference". Its
+            // identity cannot be recovered from SEQ alone, so reject the
+            // record before adding any of its observations to the matrix.
+            if record_uses_reference_equal_bases(&record) {
+                erred_records = erred_records.saturating_add(1);
+                reference_equal_records =
+                    reference_equal_records.saturating_add(1);
+                continue 'records;
+            }
+
             if self.allow_non_primary && record_is_not_primary(&record) {
                 if validate_mn_tag_on_record(&record).is_err() {
                     erred_records = erred_records.saturating_add(1);
@@ -445,6 +487,7 @@ impl<
             pileup_space.position_feature_counts = combined_counts;
             pileup_space.phased_feature_counts = [hp1, hp2];
             pileup_space.failed_records = erred_records;
+            pileup_space.reference_equal_records = reference_equal_records;
             Ok(pileup_space)
         } else {
             pileup_space.chrom_name = chrom_name;
@@ -455,6 +498,7 @@ impl<
                 .filter(|x| x.is_valid())
                 .collect();
             pileup_space.failed_records = erred_records;
+            pileup_space.reference_equal_records = reference_equal_records;
             Ok(pileup_space)
         }
     }
@@ -539,6 +583,7 @@ impl PileupWorker for GenericPileupWorker {
         mut pileup_space: ModBasePileup2,
     ) -> anyhow::Result<ModBasePileup2> {
         let mut erred_records = 0usize;
+        let mut reference_equal_records = 0usize;
         let chrom_tid = chrom_coordinates.chrom_tid;
         let start_pos = chrom_coordinates.start_pos;
         let end_pos = chrom_coordinates.end_pos;
@@ -614,6 +659,15 @@ impl PileupWorker for GenericPileupWorker {
         let mut pos_base_mod_call = Option::<BaseModCall>::None;
         let mut mod_strand = Option::<Strand>::None;
         'records: for record in records {
+            // Keep this preflight before modification parsing and tallying so
+            // a reference-equal query cannot contribute a partial record.
+            if record_uses_reference_equal_bases(&record) {
+                erred_records = erred_records.saturating_add(1);
+                reference_equal_records =
+                    reference_equal_records.saturating_add(1);
+                continue 'records;
+            }
+
             let reverse = record.is_reverse();
             let record_strand = if record.is_reverse() {
                 Strand::Negative
@@ -934,6 +988,7 @@ impl PileupWorker for GenericPileupWorker {
         pileup_space.interval_width = width;
         pileup_space.position_feature_counts = position_feature_counts;
         pileup_space.failed_records = erred_records;
+        pileup_space.reference_equal_records = reference_equal_records;
         Ok(pileup_space)
     }
 }

--- a/modkit-core/src/pileup/subcommand.rs
+++ b/modkit-core/src/pileup/subcommand.rs
@@ -1623,11 +1623,16 @@ impl ModBamPileup {
             drop(records_tx);
         });
 
+        let mut reference_equal_records = 0u64;
         for result in records_rx.into_iter() {
             match result {
                 Ok(mod_base_pileup) => {
                     tid_progress.inc(mod_base_pileup.interval_width as u64);
                     erred_reads.inc(mod_base_pileup.failed_records as u64);
+                    reference_equal_records = reference_equal_records
+                        .saturating_add(
+                            mod_base_pileup.reference_equal_records as u64,
+                        );
                     let rows_written =
                         writer.write(mod_base_pileup, &motif_labels)?;
                     write_progress.inc(rows_written);
@@ -1640,6 +1645,17 @@ impl ModBamPileup {
 
         let rows_processed = write_progress.position();
         let n_failed_reads = erred_reads.position();
+
+        if reference_equal_records > 0 {
+            master_progress.suspend(|| {
+                error!(
+                    "~{reference_equal_records} records rejected because BAM \
+                     SEQ contains '='; '=' means reference-equality and must \
+                     be resolved against the reference to an explicit base \
+                     before pileup"
+                );
+            });
+        }
 
         if n_failed_reads > 0 {
             master_progress.suspend(|| {

--- a/modkit/tests/test_pileup.rs
+++ b/modkit/tests/test_pileup.rs
@@ -13,6 +13,90 @@ use mod_kit::mod_base_code::{ModCodeRepr, METHYL_CYTOSINE};
 
 mod common;
 
+fn make_ambiguous_query_pileup_bam(bam_path: &PathBuf, overrun: bool) {
+    let mut header = bam::Header::new();
+    let mut header_record = bam::header::HeaderRecord::new(b"HD");
+    header_record.push_tag(b"VN", "1.6").push_tag(b"SO", "coordinate");
+    header.push_record(&header_record);
+    let mut reference_record = bam::header::HeaderRecord::new(b"SQ");
+    reference_record
+        .push_tag(b"SN", "oligo_1512_adapters")
+        .push_tag(b"LN", 156);
+    header.push_record(&reference_record);
+
+    let (sequence, cigar, mm_tag, ml_tag) = if overrun {
+        (
+            b"CNCTGTACTT".as_slice(),
+            bam::record::CigarString(vec![
+                bam::record::Cigar::SoftClip(1),
+                bam::record::Cigar::Match(9),
+            ]),
+            "C+m?,0,0;",
+            vec![255, 255],
+        )
+    } else {
+        (
+            b"NCTGTACTTN".as_slice(),
+            bam::record::CigarString(vec![bam::record::Cigar::Match(10)]),
+            "C+m?,0;",
+            vec![255],
+        )
+    };
+    let mut record = bam::Record::new();
+    record.set(b"ambiguous-query", Some(&cigar), sequence, &[30; 10]);
+    record.set_tid(0);
+    record.set_pos(0);
+    record.set_mapq(60);
+    record.push_aux(b"MM", bam::record::Aux::String(mm_tag)).unwrap();
+    record
+        .push_aux(b"ML", bam::record::Aux::ArrayU8((&ml_tag[..]).into()))
+        .unwrap();
+
+    let mut writer =
+        bam::Writer::from_path(bam_path, &header, bam::Format::Bam).unwrap();
+    writer.write(&record).unwrap();
+    drop(writer);
+    bam::index::build(bam_path, None, bam::index::Type::Bai, 1).unwrap();
+}
+
+type AmbiguousQueryPileupRow = (u64, ModCodeRepr, u64, u64);
+
+fn run_ambiguous_query_pileup(
+    input_bam: &PathBuf,
+    output_bed: &PathBuf,
+    optimized: bool,
+) -> Result<Vec<AmbiguousQueryPileupRow>, String> {
+    let mut args = vec![
+        "pileup",
+        input_bam.to_str().unwrap(),
+        output_bed.to_str().unwrap(),
+    ];
+    if optimized {
+        args.extend(["--modified-bases", "5mC"]);
+    }
+    args.extend([
+        "--no-filtering",
+        "--ref",
+        "../tests/resources/CGI_ladder_3.6kb_ref.fa",
+        "--threads",
+        "1",
+    ]);
+    run_modkit(&args).map_err(|error| error.to_string())?;
+
+    Ok(BufReader::new(File::open(output_bed).unwrap())
+        .lines()
+        .map(|line| BedMethylLine::parse(&line.unwrap()).unwrap())
+        .map(|row| {
+            (
+                row.start(),
+                row.raw_mod_code,
+                row.count_methylated,
+                row.valid_coverage,
+            )
+        })
+        .collect())
+}
+
 #[test]
 fn test_pileup_help() {
     let pileup_help_args = ["pileup", "--help"];
@@ -153,6 +237,62 @@ fn test_pileup_no_mod_calls() {
     let reader = BufReader::new(File::open(empty_bedfile).unwrap());
     let lines = reader.lines().collect::<Vec<Result<String, _>>>();
     assert_eq!(lines.len(), 0);
+}
+
+#[test]
+fn test_pileup_skips_ambiguous_query_and_keeps_downstream_modification() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input_bam = temp_dir.path().join("ambiguous-query.bam");
+    let optimized_output = temp_dir.path().join("optimized.bed");
+    let generic_output = temp_dir.path().join("generic.bed");
+    make_ambiguous_query_pileup_bam(&input_bam, false);
+    let observed = vec![
+        (
+            "optimized",
+            run_ambiguous_query_pileup(&input_bam, &optimized_output, true),
+        ),
+        (
+            "generic",
+            run_ambiguous_query_pileup(&input_bam, &generic_output, false),
+        ),
+    ];
+    let expected_row = (1, METHYL_CYTOSINE, 1, 1);
+
+    assert_eq!(
+        observed,
+        vec![
+            ("optimized", Ok(vec![expected_row])),
+            ("generic", Ok(vec![expected_row])),
+        ]
+    );
+}
+
+#[test]
+fn test_pileup_skips_ambiguous_query_after_unaligned_modification() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input_bam = temp_dir.path().join("ambiguous-query-overrun.bam");
+    let optimized_output = temp_dir.path().join("optimized.bed");
+    let generic_output = temp_dir.path().join("generic.bed");
+    make_ambiguous_query_pileup_bam(&input_bam, true);
+    let observed = vec![
+        (
+            "optimized",
+            run_ambiguous_query_pileup(&input_bam, &optimized_output, true),
+        ),
+        (
+            "generic",
+            run_ambiguous_query_pileup(&input_bam, &generic_output, false),
+        ),
+    ];
+    let expected_row = (1, METHYL_CYTOSINE, 1, 1);
+
+    assert_eq!(
+        observed,
+        vec![
+            ("optimized", Ok(vec![expected_row])),
+            ("generic", Ok(vec![expected_row])),
+        ]
+    );
 }
 
 #[test]

--- a/modkit/tests/test_pileup.rs
+++ b/modkit/tests/test_pileup.rs
@@ -59,13 +59,47 @@ fn make_ambiguous_query_pileup_bam(bam_path: &PathBuf, overrun: bool) {
     bam::index::build(bam_path, None, bam::index::Type::Bai, 1).unwrap();
 }
 
-type AmbiguousQueryPileupRow = (u64, ModCodeRepr, u64, u64);
+fn make_reference_equal_query_pileup_bam(bam_path: &PathBuf) {
+    let mut header = bam::Header::new();
+    let mut header_record = bam::header::HeaderRecord::new(b"HD");
+    header_record.push_tag(b"VN", "1.6").push_tag(b"SO", "coordinate");
+    header.push_record(&header_record);
+    let mut reference_record = bam::header::HeaderRecord::new(b"SQ");
+    reference_record
+        .push_tag(b"SN", "oligo_1512_adapters")
+        .push_tag(b"LN", 156);
+    header.push_record(&reference_record);
 
-fn run_ambiguous_query_pileup(
+    let cigar = bam::record::CigarString(vec![bam::record::Cigar::Match(10)]);
+    let mut writer =
+        bam::Writer::from_path(bam_path, &header, bam::Format::Bam).unwrap();
+    for (name, sequence) in [
+        (b"reference-equal".as_slice(), b"C=TGTACTTC".as_slice()),
+        (b"valid-control".as_slice(), b"CCTGTACTTC".as_slice()),
+    ] {
+        let mut record = bam::Record::new();
+        record.set(name, Some(&cigar), sequence, &[30; 10]);
+        record.set_tid(0);
+        record.set_pos(0);
+        record.set_mapq(60);
+        record.push_aux(b"MM", bam::record::Aux::String("C+m?,0;")).unwrap();
+        record
+            .push_aux(b"ML", bam::record::Aux::ArrayU8((&[255][..]).into()))
+            .unwrap();
+        writer.write(&record).unwrap();
+    }
+    drop(writer);
+    bam::index::build(bam_path, None, bam::index::Type::Bai, 1).unwrap();
+}
+
+type QueryPileupRow = (u64, ModCodeRepr, u64, u64);
+
+fn run_query_pileup(
     input_bam: &PathBuf,
     output_bed: &PathBuf,
     optimized: bool,
-) -> Result<Vec<AmbiguousQueryPileupRow>, String> {
+    log_path: Option<&PathBuf>,
+) -> Result<Vec<QueryPileupRow>, String> {
     let mut args = vec![
         "pileup",
         input_bam.to_str().unwrap(),
@@ -81,6 +115,9 @@ fn run_ambiguous_query_pileup(
         "--threads",
         "1",
     ]);
+    if let Some(log_path) = log_path {
+        args.extend(["--log", log_path.to_str().unwrap()]);
+    }
     run_modkit(&args).map_err(|error| error.to_string())?;
 
     Ok(BufReader::new(File::open(output_bed).unwrap())
@@ -249,12 +286,9 @@ fn test_pileup_skips_ambiguous_query_and_keeps_downstream_modification() {
     let observed = vec![
         (
             "optimized",
-            run_ambiguous_query_pileup(&input_bam, &optimized_output, true),
+            run_query_pileup(&input_bam, &optimized_output, true, None),
         ),
-        (
-            "generic",
-            run_ambiguous_query_pileup(&input_bam, &generic_output, false),
-        ),
+        ("generic", run_query_pileup(&input_bam, &generic_output, false, None)),
     ];
     let expected_row = (1, METHYL_CYTOSINE, 1, 1);
 
@@ -277,12 +311,9 @@ fn test_pileup_skips_ambiguous_query_after_unaligned_modification() {
     let observed = vec![
         (
             "optimized",
-            run_ambiguous_query_pileup(&input_bam, &optimized_output, true),
+            run_query_pileup(&input_bam, &optimized_output, true, None),
         ),
-        (
-            "generic",
-            run_ambiguous_query_pileup(&input_bam, &generic_output, false),
-        ),
+        ("generic", run_query_pileup(&input_bam, &generic_output, false, None)),
     ];
     let expected_row = (1, METHYL_CYTOSINE, 1, 1);
 
@@ -293,6 +324,41 @@ fn test_pileup_skips_ambiguous_query_after_unaligned_modification() {
             ("generic", Ok(vec![expected_row])),
         ]
     );
+}
+
+#[test]
+fn test_pileup_rejects_reference_equal_query_before_tallying() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let input_bam = temp_dir.path().join("reference-equal-query.bam");
+    make_reference_equal_query_pileup_bam(&input_bam);
+    let expected_row = (0, METHYL_CYTOSINE, 1, 1);
+
+    for (label, optimized) in [("optimized", true), ("generic", false)] {
+        let output_bed = temp_dir.path().join(format!("{label}.bed"));
+        let log_path = temp_dir.path().join(format!("{label}.log"));
+        let rows = run_query_pileup(
+            &input_bam,
+            &output_bed,
+            optimized,
+            Some(&log_path),
+        )
+        .unwrap();
+        let log = std::fs::read_to_string(log_path).unwrap();
+
+        assert_eq!(rows, vec![expected_row], "{label}");
+        assert!(
+            log.contains("~1 records rejected because BAM SEQ contains '='"),
+            "{label}: {log}"
+        );
+        assert!(
+            log.contains(
+                "'=' means reference-equality and must be resolved against \
+                 the reference to an explicit base before pileup"
+            ),
+            "{label}: {log}"
+        );
+        assert!(log.contains("~1 failed processing"), "{label}: {log}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
<!-- Suggested title: Preserve pileup calls around ambiguous query bases -->

Fixes #668.

## Summary

- Prevents valid BAM IUPAC query symbols from panicking optimized or generic pileup paths.
- Skips only an unclassifiable aligned observation while preserving pending state and valid downstream modification calls from the same record.
- Keeps ambiguity symbols from consuming A/C/G/T MM deltas and complements BAM IUPAC ambiguity pairs for reverse reads.
- Rejects a record containing the distinct SAM/BAM reference-equality symbol `=` before tallying and reports it through one aggregate diagnostic; resolving `=` from the reference is not implemented here.
- Adds exact forward/reverse adapter, optimized/generic CLI, packed-sequence, and release direct-RNA hot-loop regressions.

## Severity

**Severity:** High — scientific completeness and reliability

**Rationale:** Accepted ambiguity can silently remove valid downstream modified calls and coverage while the command exits successfully, or can panic after writing partial output. This can bias pileup counts toward reads without ambiguous observations.

## Root cause

The optimized reverse scanner treated every non-ACGT query symbol as unreachable and its complement helper panicked outside A/C/G/T. In both pileup workers, several aligned-position conversions either unwrapped an ambiguous query base or abandoned the entire record. One overrun path also advanced the modification iterator before converting the current query base but saved that pending state only after the fallible conversion, so skipping the observation lost downstream state.

## Implementation

- Ignore non-ACGT symbols when calculating optimized reverse-read A/C/G/T frequencies used by MM deltas.
- Explicitly complement the BAM IUPAC ambiguity pairs, including `R/Y`, `M/K`, `B/V`, `D/H`, `S`, `W`, and `N`.
- Centralize aligned query-base conversion in an inline, allocation-free helper returning `Option<DnaBase>`.
- In optimized and generic overrun paths, save the already-advanced pending modification state before attempting to classify the current query observation.
- Continue the aligned-position loop when only that observation is ambiguous; do not increment the failed-record count.
- Scan the packed BAM sequence for code zero (`=`) before either worker parses modifications or changes a tally. Reject that complete record, increment the existing failed-record total and a dedicated approximate counter, and emit one final explanation of the reference-resolution requirement.

### Preserved behavior

- A/C/G/T MM deltas, ML probabilities, thresholding, strand semantics, output schema, and worker scheduling remain unchanged.
- Ambiguous observations are excluded from every bedMethyl category, including `N_diff`; no A/C/G/T identity is invented.
- The tested canonical-only direct-RNA optimized release control is byte-identical.
- No allocation, clone, lock, sort, or synchronization is added per aligned position. The `=` guard adds one allocation-free packed-byte scan per processed record.

### Non-goals

- No support claim for MM groups whose fundamental base is `N` or `U`, negative-strand MM groups, or malformed MM/ML recovery.
- No reference-backed resolution of `SEQ =`; affected records are rejected before tallying and pileup continues. Deciding whether unresolved IUPAC observations should increment `N_diff` is separate policy work.
- No generic record-error policy, output rollback/atomicity, threshold, schema, scheduler, or broader performance redesign.
- No requirement that existing optimized and generic motif labels be byte-identical where their selected reference-position scopes already differ.
- This branch materially overlaps [PR #597](https://github.com/nanoporetech/modkit/pull/597): both ignore non-ACGT symbols in reverse-frequency accounting and make several aligned query-base conversions position-local. This branch extends that work by covering q-before-next-mod handling in both workers, generic overrun/pending-state preservation, BAM IUPAC ambiguity complements, explicit `=` rejection, and exact optimized/generic scientific and performance oracles. The maintainer should choose or combine the implementations rather than merge both overlapping diffs independently.

## Behavior before and after

| Case | Before | After | Expected oracle |
|---|---|---|---|
| Leading `N` before a valid downstream 5mC call | Both workers can abandon the record and emit no row while exiting zero | Skip the ambiguous observation and retain the call | Exact downstream row at `chr1:1-2`, modified count/valid coverage 1 |
| Soft-clipped earlier call, then aligned ambiguity before a later call | Conversion unwrap can panic | Pending state is saved before the ambiguity is skipped | Same exact downstream 5mC row in both workers |
| Reverse read containing BAM ambiguity | Reverse frequency/complement path can panic | IUPAC is complemented without consuming A/C/G/T deltas | Both paired forward/reverse rows emitted; 102-byte SHA-256 `5a315a8f4557d043736415c4f9743619f39f8f7d31974b3ed620708859df1784` |
| Record containing `SEQ =` plus a valid earlier call | Treating `=` as ordinary ambiguity can silently include only part of the record | Reject the complete record before any tally; retain an otherwise identical control record and log the reason once in aggregate | Optimized and generic output exactly one modified call with valid coverage 1, not 2; both report one reference-equality rejection |
| Ordinary direct-RNA input without ambiguous query bases in the sampled scan | Existing output | Byte-identical | 60,959 rows, 9,989,028 bytes, SHA-256 `a85202b69e79e708656e71858e4243cb1cc51e22a44bb9f65650a23dacb407fa` |

## Testing

**Test environment**

- Revision tested: `bb20328778b2a5e3f0f815b36af2ae09c1df7ae7`
- Tree tested and worktree state: `7cc1afd1313f8af725dd34635a4620c704a774fe`; clean after testing
- Toolchain: rustc/cargo 1.90.0
- Platform: macOS 26.6, arm64 Apple Silicon
- Reference binary: installed modkit 0.6.4 and exact upstream parent `5cecc3fb3a9336068d9e3c68d5c08d678153dd2c`
- External tools: samtools 1.23.1
- Dependency resolution identity: ignored `Cargo.lock` SHA-256 `f9d3389f8fc63c9ad653dad3fbf43a1c26cc54008f0a39e06e71ff6455a1e9b5`; `rust-htslib` 0.46.0, `hts-sys` 2.2.0

| Test layer | Exact command, fixture, or matrix | Result and evidence |
|---|---|---|
| **Core: parent-red regression** | Installed 0.6.4 and exact parent; leading ambiguity, softclip-overrun ambiguity, and paired reverse fixtures | Leading case silently loses the downstream call; softclip/reverse cases exit 101; partial paired output SHA-256 `794047e609d4b3993f27bff54b1a6249c93d1d472668b0f766a91fd761eb4f6d` |
| **Core: focused adapter regression** | `cargo test -p mod_kit pileup::base_mods_adapter::base_mods_adapter_tests::test_ambiguous_query_bases_preserve_mm_scanning -- --exact --test-threads=1` | 1 passed, 0 failed; forward/reverse R/N/Y positions and ML-derived qualities are exact |
| Adapter module | `cargo test -p mod_kit base_mods_adapter_tests --lib -- --test-threads=1` | 9 passed, 0 failed |
| Packed-sequence guard | `cargo test --offline --locked -p mod_kit pileup::pileup_processor::reference_equal_base_tests::odd_length_padding_is_not_a_reference_equal_base --lib -- --exact --test-threads=1` | 1 passed, 0 failed; a real `=` is detected and an odd-length BAM record's unused low padding nibble is not |
| **Core: `=` no-partial-tally regression** | `cargo test --offline --locked -p modkit --test test_pileup test_pileup_rejects_reference_equal_query_before_tallying -- --exact --test-threads=1` | 1 passed, 0 failed; optimized and generic paths retain only the valid control's exact 1/1 call and log both the explicit rejection and failed-record total |
| **Core: affected pileup integration** | `cargo test -p modkit --test test_pileup -- --test-threads=1` | 19 passed, 10 ignored, 0 failed; both IUPAC tests and the `=` rejection test exercise optimized and generic workers |
| **Core: applicable full workspace gate** | `TMPDIR=/private/tmp/modkit-668-supervisor-full-bb20328 cargo test --offline --locked --workspace --all-targets --no-fail-fast -- --test-threads=1` | 184 passed, 14 ignored, 0 failed on the exact final head |
| Installed-versus-fixed comparison | Public inline SAM/BAM fixtures in issue #668 | Four optimized/generic downstream outputs are each the exact 50-byte row, SHA-256 `41458d8efc760a6849bbc6e95f2322be5d02c4a602ec4e24d24325d942866319`; paired reverse output matches the behavior table |
| `=` branch guard | Matched two-record optimized/generic fixture on the parent behavior and final branch | The parent includes both valid q0 calls as 2/2 without a reference-equality diagnostic; the final branch deliberately rejects the unresolved `=` record before tallying and emits exact 1/1 from the valid control. This guards the branch's `=` boundary rather than reproducing issue #668's original IUPAC defect |
| Optimized/generic semantic parity | Leading and softclip-overrun fixtures | Both workers emit the same scientific position, modification identity, count, and coverage without failed-record inflation |
| Exact release artifact | `cargo build --offline --locked --release -p modkit` at the tested head | 23,833,584-byte binary, SHA-256 `fb9dff56b0b5ec233e5f65f5fed6eb4e029dd408ca4a314c92ca293307f0a4e1`; the earlier pre-`=` artifact did not match and its timing was discarded |
| Real-data performance and byte guard | Reconstructed command: `modkit pileup rna_top50_tx.bam OUT --reference rna_top50_tx.padded.fa --modified-bases C:m A:a A:17596 T:17802 --no-filtering --threads 8 --io-threads 4 --suppress-progress`; 898,198,413-byte/1,632,831-read direct-RNA BAM; one warm-up then U1/F1/U2/F2/U3/F3 release runs | Upstream wall/user/sys medians 6.87/23.73/0.32 s and means 6.8467/23.7133/0.3200 s; final medians 6.75/23.15/0.32 s and means 6.7567/23.1467/0.3200 s. The small apparent improvement is treated as run/build noise, not a speedup claim; no material regression is measurable. All six timed outputs and both warm-ups are byte-identical with the hash/count above |
| Generic unaffected control | One release generic run per exact upstream/final binary with the same command minus `--modified-bases` | Both outputs byte-identical: 131,900 rows, 20,887,346 bytes, SHA-256 `2c98dc0193764a410a8d84b1227733ec101f47db5541ec7c313e7d07e1a447c8`; raw generic/optimized files are intentionally not compared because their selected reference-position scopes differ |
| Hot-loop source/layout audit | `get_query_base`, packed `=` preflight, adapter frequency/complement, and both overrun state paths | O(1) borrowed aligned-base access; one allocation-free sequential scan over approximately half the sequence bytes per fetched record exposure; no lock/atomic/synchronization change. Existing or newly advanced pending state is preserved across each ambiguity skip, with newly advanced state saved before fallible conversion in both overrun branches. A read crossing K chunks is scanned K times, matching existing per-exposure processing; the default 1 Mb interval makes K=1 for every active contig in this control |
| **Core: formatting/diff checks** | Direct stable `rustfmt --check` on all five changed Rust files; `git diff --check upstream/master...HEAD` | Passed; only upstream nightly-setting warnings were emitted |

### Tests not performed

- The adapter test samples representative `R/N/Y` symbols rather than enumerating every IUPAC ambiguity symbol, although the source explicitly covers every supported ambiguity complement pair.
- The sampled 100,000-primary-record real-data scan contained no non-ACGT query bases; it is therefore a normal-hot-loop regression guard, not a real-data correctness exposure test.
- The literal earlier benchmark command was not retained; the command reported above was reconstructed and accepted only after reproducing the prior exact row/byte/SHA oracle.
- The ordinary-IUPAC integration does not parse `N_diff` directly; exclusion from `N_diff` is established by both workers skipping before every tally method.
- No output rollback, malformed-tag, negative-strand-MM, or GPU test was run because those paths are outside scope.

## Scientific validation

- Population/eligibility invariant: one ambiguous aligned observation is skipped without removing the rest of an otherwise usable record.
- Downstream-call preservation invariant: each IUPAC fixture retains exactly one downstream modified call and its unit valid coverage; ambiguity itself contributes to no bedMethyl category, including `N_diff`.
- Whole-record rejection invariant: a record containing unresolved `=` contributes no partial call, while the matched valid control contributes exactly one call and unit coverage in both workers.
- Coordinate/strand/interval invariant: forward/reverse MM deltas count only their fundamental A/C/G/T bases and retain exact query/reference positions.
- Determinism invariant: fixed optimized/generic synthetic outputs agree scientifically; normal-path release artifacts are byte-identical across all A/B runs.
- Independent oracle or specialist review: MM delta positions and ML values are directly enumerable; CPU and supervisor reviews traced every state-save branch and verified the hot-loop cost.

## Output and compatibility

- User-visible change: valid IUPAC symbols no longer panic or discard downstream pileup calls.
- Expected output differences: affected IUPAC reads recover scientifically usable downstream calls and coverage; the ambiguous position itself remains unclassified. A record containing `=` is rejected before tallying and produces an aggregate error log because the base identity requires reference resolution.
- Byte-identical controls: normal direct-RNA optimized and generic release controls are byte-identical to the parent.
- CLI/API/schema compatibility: no option, public API, column, or schema change.
- Partial-output or failure semantics: ordinary ambiguity is position-local; unresolved `=` is whole-record-fatal but not process-fatal, and the command continues after logging aggregate rejection/failure counts. This PR does not make output transactional for unrelated fatal errors.

## Reviewer guide

1. Review reverse frequency/complement handling in `base_mods_adapter.rs`.
2. Review the packed-nibble `=` preflight, including its odd-length padding rule, and confirm it precedes all tally mutation in both workers.
3. Review the inline `get_query_base` helper and confirm every ordinary-IUPAC `None` branch skips only the current position.
4. Pay particular attention to pending-state assignments before `break 'overran` in both workers.
5. Rerun the adapter, two IUPAC, packed-padding, and `=` no-partial-tally regressions.
6. Compare the bounded additions with PR #597 and retain the direct-RNA performance evidence requested there.

## Checklist

- [x] The issue contains reproducible observed and expected behavior.
- [x] The change is limited to the linked issue's approved scope.
- [x] The regressions are demonstrably red on the exact parent/released binary.
- [x] All tests actually performed are listed above with their results.
- [x] Unrun or inapplicable tests are disclosed.
- [x] Scientific counts/statistics and output compatibility are explicitly checked.
- [x] Formatting and diff-hygiene checks pass, or unrelated findings are documented.
- [x] No generated data, private sample identifiers, or unrelated changes are included.
